### PR TITLE
feat: add GZIP support

### DIFF
--- a/src/main/java/com/influxdb/v3/client/config/InfluxDBClientConfigs.java
+++ b/src/main/java/com/influxdb/v3/client/config/InfluxDBClientConfigs.java
@@ -42,6 +42,7 @@ public final class InfluxDBClientConfigs {
     private final String organization;
     private final String database;
     private final WritePrecision writePrecision;
+    private final Integer gzipThreshold;
     private final Duration responseTimeout;
     private final Boolean allowHttpRedirects;
     private final Boolean disableServerCertificateValidation;
@@ -97,6 +98,14 @@ public final class InfluxDBClientConfigs {
     }
 
     /**
+     * Gets the threshold for compressing request body using GZIP.
+     *
+     * @return the threshold (in bytes)
+     */
+    @Nonnull
+    public Integer getGzipThreshold() { return gzipThreshold; }
+
+    /**
      * Gets the default response timeout to use for the API calls. Default to '10 seconds'.
      *
      * @return the default response timeout to use for the API calls
@@ -148,6 +157,7 @@ public final class InfluxDBClientConfigs {
                 && Objects.equals(organization, that.organization)
                 && Objects.equals(database, that.database)
                 && writePrecision == that.writePrecision
+                && Objects.equals(gzipThreshold,that.gzipThreshold)
                 && Objects.equals(responseTimeout, that.responseTimeout)
                 && Objects.equals(allowHttpRedirects, that.allowHttpRedirects)
                 && Objects.equals(disableServerCertificateValidation, that.disableServerCertificateValidation);
@@ -155,7 +165,7 @@ public final class InfluxDBClientConfigs {
 
     @Override
     public int hashCode() {
-        return Objects.hash(hostUrl, Arrays.hashCode(authToken), organization, database, writePrecision,
+        return Objects.hash(hostUrl, Arrays.hashCode(authToken), organization, database, writePrecision, gzipThreshold,
                 responseTimeout, allowHttpRedirects, disableServerCertificateValidation);
     }
 
@@ -166,6 +176,7 @@ public final class InfluxDBClientConfigs {
                 .add("organization='" + organization + "'")
                 .add("database='" + database + "'")
                 .add("writePrecision=" + writePrecision)
+                .add("gzipThreshold=" + gzipThreshold)
                 .add("responseTimeout=" + responseTimeout)
                 .add("allowHttpRedirects=" + allowHttpRedirects)
                 .add("disableServerCertificateValidation=" + disableServerCertificateValidation)
@@ -183,6 +194,7 @@ public final class InfluxDBClientConfigs {
         private String organization;
         private String database;
         private WritePrecision writePrecision;
+        private Integer gzipThreshold;
         private Duration responseTimeout;
         private Boolean allowHttpRedirects;
         private Boolean disableServerCertificateValidation;
@@ -255,6 +267,19 @@ public final class InfluxDBClientConfigs {
         }
 
         /**
+         * Sets the threshold for request body to be gzipped.
+         *
+         * @param gzipThreshold threshold in bytes for request body to be gzipped
+         * @return this
+         */
+        @Nonnull
+        public Builder gzipThreshold(@Nullable final Integer gzipThreshold) {
+
+            this.gzipThreshold = gzipThreshold;
+            return this;
+        }
+
+        /**
          * Sets the default response timeout to use for the API calls. Default to '10 seconds'.
          *
          * @param responseTimeout default response timeout to use for the API calls. Default to '10 seconds'.
@@ -310,7 +335,8 @@ public final class InfluxDBClientConfigs {
         authToken = builder.authToken;
         organization = builder.organization;
         database = builder.database;
-        writePrecision = builder.writePrecision;
+        writePrecision = builder.writePrecision != null ? builder.writePrecision : WritePrecision.NS;
+        gzipThreshold = builder.gzipThreshold != null ? builder.gzipThreshold : 1000;
         responseTimeout = builder.responseTimeout != null ? builder.responseTimeout : Duration.ofSeconds(10);
         allowHttpRedirects = builder.allowHttpRedirects != null ? builder.allowHttpRedirects : false;
         disableServerCertificateValidation = builder.disableServerCertificateValidation != null

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -108,8 +108,8 @@ final class RestClient implements AutoCloseable {
 
     void request(@Nonnull final String path,
                  @Nonnull final HttpMethod method,
-                 @Nullable final String data,
-                 @Nullable final String contentType,
+                 @Nullable final byte[] data,
+                 @Nullable final Map<String, String> headers,
                  @Nullable final Map<String, String> queryParams) {
 
         QueryStringEncoder uriEncoder = new QueryStringEncoder(String.format("%s%s", baseUrl, path));
@@ -132,11 +132,13 @@ final class RestClient implements AutoCloseable {
 
         // method and body
         request.method(method.name(), data == null
-                ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(data));
+                ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofByteArray(data));
 
         // headers
-        if (contentType != null) {
-            request.header("Content-Type", contentType);
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                request.header(entry.getKey(), entry.getValue());
+            }
         }
         request.header("User-Agent", userAgent);
         if (configs.getAuthToken() != null && configs.getAuthToken().length > 0) {

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -85,7 +85,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     void databaseParameterSpecified() throws InterruptedException {
         mockServer.enqueue(createResponse(200));
 
-        client.writeRecord("mem,tag=one value=1.0", new WriteParameters("my-database-2", null, null));
+        client.writeRecord("mem,tag=one value=1.0", new WriteParameters("my-database-2", null, null, null));
 
         Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(1);
         RecordedRequest request = mockServer.takeRequest();
@@ -126,7 +126,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     void precisionParameterSpecified() throws InterruptedException {
         mockServer.enqueue(createResponse(200));
 
-        client.writeRecord("mem,tag=one value=1.0", new WriteParameters(null, null, WritePrecision.S));
+        client.writeRecord("mem,tag=one value=1.0", new WriteParameters(null, null, WritePrecision.S, null));
 
         Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(1);
         RecordedRequest request = mockServer.takeRequest();
@@ -144,7 +144,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
                         .measurement("h2o")
                         .addTag("location", "europe")
                         .addField("level", 2),
-                new WriteParameters(null, "my-org", null)
+                new WriteParameters(null, "my-org", null, null)
         );
 
         Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(1);
@@ -172,7 +172,21 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     }
 
     @Test
-    void contentType() throws InterruptedException {
+    void gzip() throws InterruptedException {
+        mockServer.enqueue(createResponse(200));
+
+        client.writeRecord("mem,tag=one value=1.0", new WriteParameters(null, null, WritePrecision.S, 1));
+
+        Assertions.assertThat(mockServer.getRequestCount()).isEqualTo(1);
+        RecordedRequest request = mockServer.takeRequest();
+        Assertions.assertThat(request).isNotNull();
+        Assertions.assertThat(request.getRequestUrl()).isNotNull();
+        Assertions.assertThat(request.getHeader("Content-Type")).isEqualTo("text/plain; charset=utf-8");
+        Assertions.assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip");
+    }
+
+    @Test
+    void contentHeaders() throws InterruptedException {
         mockServer.enqueue(createResponse(200));
 
         client.writeRecord("mem,tag=one value=1.0");
@@ -181,6 +195,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         Assertions.assertThat(request).isNotNull();
         Assertions.assertThat(request.getHeader("Content-Type")).isEqualTo("text/plain; charset=utf-8");
+        Assertions.assertThat(request.getHeader("Content-Encoding")).isNull();
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/write/WriteParametersTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteParametersTest.java
@@ -44,29 +44,32 @@ class WriteParametersTest {
                 .database("my-database")
                 .organization("my-org")
                 .writePrecision(WritePrecision.S)
+                .gzipThreshold(512)
                 .build();
 
-        WriteParameters parameters = new WriteParameters(null, null, null);
+        WriteParameters parameters = new WriteParameters(null, null, null, null);
 
         Assertions.assertThat(parameters.databaseSafe(options)).isEqualTo("my-database");
         Assertions.assertThat(parameters.organizationSafe(options)).isEqualTo("my-org");
         Assertions.assertThat(parameters.precisionSafe(options)).isEqualTo(WritePrecision.S);
+        Assertions.assertThat(parameters.gzipThresholdSafe(options)).isEqualTo(512);
     }
 
     @Test
     void nullableParameters() {
         InfluxDBClientConfigs options = optionsBuilder.database("my-database").organization("my-org").build();
 
-        WriteParameters parameters = new WriteParameters(null, null, null);
+        WriteParameters parameters = new WriteParameters(null, null, null, null);
 
         Assertions.assertThat(parameters.precisionSafe(options)).isEqualTo(WritePrecision.NS);
+        Assertions.assertThat(parameters.gzipThresholdSafe(options)).isEqualTo(1000);
     }
 
     @Test
     void npe() {
-        WriteParameters parameters = new WriteParameters(null, null, null);
+        WriteParameters parameters = new WriteParameters(null, null, null, null);
 
         Assertions.assertThat(parameters.hashCode()).isNotNull();
-        Assertions.assertThat(parameters).isEqualTo(new WriteParameters(null, null, null));
+        Assertions.assertThat(parameters).isEqualTo(new WriteParameters(null, null, null, null));
     }
 }


### PR DESCRIPTION
## Proposed Changes

Based on `gzipThreshold` option, payload body can be compressed using GZIP. Solution similar to other clients (JS, Go, C#).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
