### PR TITLE
feat: create Client from connection string, environment variables or system properties

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,5 +1,8 @@
 {
   "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  },
   "MD033": {
     "allowed_elements": [ "a", "img", "p" ]
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.3.0 [unreleased]
 
+### Features
+
+1. [#40](https://github.com/InfluxCommunity/influxdb3-java/pull/40): Add client creation from connection string,
+environment variables or system properties.
+
 ## 0.2.0 [2023-08-11]
 
 ### Features

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -220,11 +220,11 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * Supported parameters:
      * <ul>
-     *   <li>token (required)</li>
-     *   <li>org</li>
-     *   <li>database</li>
-     *   <li>precision</li>
-     *   <li>gzipThreshold</li>
+     *   <li>token - authentication token <i>(required)</i></li>
+     *   <li>org - organization name</li>
+     *   <li>database - database (bucket) name</li>
+     *   <li>precision - timestamp precision when writing data</li>
+     *   <li>gzipThreshold - payload size size for gzipping data</li>
      * </ul>
      *
      * @param connectionString connection string
@@ -250,21 +250,21 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * Supported environment variables:
      * <ul>
-     *   <li>INFLUX_HOST <i>required</i></li>
-     *   <li>INFLUX_TOKEN <i>required</i></li>
-     *   <li>INFLUX_ORG</li>
-     *   <li>INFLUX_DATABASE</li>
-     *   <li>INFLUX_PRECISION</li>
-     *   <li>INFLUX_GZIP_THRESHOLD</li>
+     *   <li>INFLUX_HOST - cloud/server URL <i>required</i></li>
+     *   <li>INFLUX_TOKEN - authentication token <i>required</i></li>
+     *   <li>INFLUX_ORG - organization name</li>
+     *   <li>INFLUX_DATABASE - database (bucket) name</li>
+     *   <li>INFLUX_PRECISION - timestamp precision when writing data</li>
+     *   <li>INFLUX_GZIP_THRESHOLD - payload size size for gzipping data</li>
      * </ul>
      * Supported system properties:
      * <ul>
-     *   <li>influx.host <i>required</i></li>
-     *   <li>influx.token <i>required</i></li>
-     *   <li>influx.org</li>
-     *   <li>influx.database</li>
-     *   <li>influx.precision</li>
-     *   <li>influx.gzipThreshold</li>
+     *   <li>influx.host - cloud/server URL <i>required</i></li>
+     *   <li>influx.token - authentication token <i>required</i></li>
+     *   <li>influx.org - organization name</li>
+     *   <li>influx.database - database (bucket) name</li>
+     *   <li>influx.precision - timestamp precision when writing data</li>
+     *   <li>influx.gzipThreshold - payload size size for gzipping data</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.v3.client;
 
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -206,5 +207,63 @@ public interface InfluxDBClient extends AutoCloseable {
     @Nonnull
     static InfluxDBClient getInstance(@Nonnull final ClientConfig config) {
         return new InfluxDBClientImpl(config);
+    }
+
+    /**
+     * Creates a new instance of the {@link InfluxDBClient} from the connection string in URL format.
+     * <p>
+     * Example:
+     * <pre>
+     * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database");
+     * </pre>
+     * </p>
+     * Supported parameters:
+     * <ul>
+     *   <li>token (required)</li>
+     *   <li>org</li>
+     *   <li>database</li>
+     *   <li>precision</li>
+     *   <li>gzipThreshold</li>
+     * </ul>
+     * </p>
+     *
+     * @param connectionString connection string
+     * @return instance of {@link InfluxDBClient}
+     */
+    @Nonnull
+    static InfluxDBClient getInstance(@Nonnull final String connectionString) throws MalformedURLException {
+        return getInstance(new ClientConfig.Builder().build(connectionString));
+    }
+
+    /**
+     * Creates a new instance of the {@link InfluxDBClient} from environment variables and/or system properties.
+     * Environment variables take precedence over system properties.
+     * <p>
+     * Example:
+     * <pre>
+     * client = InfluxDBClient.getInstance();
+     * </pre>
+     * </p>
+     * Supported environment variables:
+     * <ul>
+     *   <li>INFLUX_HOST <i>required</i></li>
+     *   <li>INFLUX_TOKEN <i>required</i></li>
+     *   <li>INFLUX_ORG</li>
+     *   <li>INFLUX_DATABASE</li>
+     * </ul>
+     * Supported system properties:
+     * <ul>
+     *   <li>influx.host <i>required</i></li>
+     *   <li>influx.token <i>required</i></li>
+     *   <li>influx.org</li>
+     *   <li>influx.database</li>
+     * </ul>
+     * </p>
+     *
+     * @return instance of {@link InfluxDBClient}
+     */
+    @Nonnull
+    static InfluxDBClient getInstance() {
+        return getInstance(new ClientConfig.Builder().build(System.getenv(), System.getProperties()));
     }
 }

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -214,7 +214,8 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * Example:
      * <pre>
-     * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&amp;database=my-database");
+     * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/"
+     *         + "?token=my-token&amp;database=my-database");
      * </pre>
      * <p>
      * Supported parameters:

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -216,7 +216,6 @@ public interface InfluxDBClient extends AutoCloseable {
      * <pre>
      * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database");
      * </pre>
-     * </p>
      * <p>
      * Supported parameters:
      * <ul>
@@ -226,7 +225,6 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>precision</li>
      *   <li>gzipThreshold</li>
      * </ul>
-     * </p>
      *
      * @param connectionString connection string
      * @return instance of {@link InfluxDBClient}
@@ -248,7 +246,6 @@ public interface InfluxDBClient extends AutoCloseable {
      * <pre>
      * client = InfluxDBClient.getInstance();
      * </pre>
-     * </p>
      * <p>
      * Supported environment variables:
      * <ul>
@@ -264,7 +261,6 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.org</li>
      *   <li>influx.database</li>
      * </ul>
-     * </p>
      *
      * @return instance of {@link InfluxDBClient}
      */

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -214,7 +214,7 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * Example:
      * <pre>
-     * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database");
+     * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&amp;database=my-database");
      * </pre>
      * <p>
      * Supported parameters:

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -254,6 +254,8 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>INFLUX_TOKEN <i>required</i></li>
      *   <li>INFLUX_ORG</li>
      *   <li>INFLUX_DATABASE</li>
+     *   <li>INFLUX_PRECISION</li>
+     *   <li>INFLUX_GZIP_THRESHOLD</li>
      * </ul>
      * Supported system properties:
      * <ul>
@@ -261,6 +263,8 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.token <i>required</i></li>
      *   <li>influx.org</li>
      *   <li>influx.database</li>
+     *   <li>influx.precision</li>
+     *   <li>influx.gzipThreshold</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -217,6 +217,7 @@ public interface InfluxDBClient extends AutoCloseable {
      * client = InfluxDBClient.getInstance("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database");
      * </pre>
      * </p>
+     * <p>
      * Supported parameters:
      * <ul>
      *   <li>token (required)</li>
@@ -231,8 +232,12 @@ public interface InfluxDBClient extends AutoCloseable {
      * @return instance of {@link InfluxDBClient}
      */
     @Nonnull
-    static InfluxDBClient getInstance(@Nonnull final String connectionString) throws MalformedURLException {
-        return getInstance(new ClientConfig.Builder().build(connectionString));
+    static InfluxDBClient getInstance(@Nonnull final String connectionString) {
+        try {
+            return getInstance(new ClientConfig.Builder().build(connectionString));
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e); // same exception as ClientConfig.validate()
+        }
     }
 
     /**
@@ -244,6 +249,7 @@ public interface InfluxDBClient extends AutoCloseable {
      * client = InfluxDBClient.getInstance();
      * </pre>
      * </p>
+     * <p>
      * Supported environment variables:
      * <ul>
      *   <li>INFLUX_HOST <i>required</i></li>

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -22,12 +22,17 @@
 package com.influxdb.v3.client.config;
 
 import java.net.Authenticator;
+import java.net.MalformedURLException;
 import java.net.ProxySelector;
+import java.net.URL;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.StringJoiner;
+import java.util.function.BiFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -450,6 +455,95 @@ public final class ClientConfig {
          */
         @Nonnull
         public ClientConfig build() {
+            return new ClientConfig(this);
+        }
+
+        /**
+         * Build an instance of {@code ClientConfig} from connection string.
+         *
+         * @param connectionString connection string in URL format
+         * @return the configuration for an {@code InfluxDBClient}.
+         */
+        @Nonnull
+        public ClientConfig build(@Nonnull final String connectionString) throws MalformedURLException {
+            final URL url = new URL(connectionString);
+            final Map<String, String> parameters = new HashMap<>();
+            final String[] pairs = url.getQuery().split("&");
+            for (String pair : pairs) {
+                int idx = pair.indexOf("=");
+                parameters.put(pair.substring(0, idx), pair.substring(idx + 1));
+            }
+            this.host(new URL(url.getProtocol(), url.getHost(), url.getPort(), url.getPath()).toString());
+            if (parameters.containsKey("token")) {
+                this.token(parameters.get("token").toCharArray());
+            }
+            if (parameters.containsKey("org")) {
+                this.organization(parameters.get("org"));
+            }
+            if (parameters.containsKey("database")) {
+                this.database(parameters.get("database"));
+            }
+            if (parameters.containsKey("precision")) {
+                String value = parameters.get("precision");
+                WritePrecision precision;
+                switch (value) {
+                    case "ns":
+                        precision = WritePrecision.NS;
+                        break;
+                    case "us":
+                        precision = WritePrecision.US;
+                        break;
+                    case "ms":
+                        precision = WritePrecision.MS;
+                        break;
+                    case "s":
+                        precision = WritePrecision.S;
+                        break;
+                    default:
+                        throw new IllegalArgumentException(String.format("unsupported precision %s", value));
+                }
+                this.writePrecision(precision);
+            }
+            if (parameters.containsKey("gzipThreshold")) {
+                this.gzipThreshold(Integer.parseInt(parameters.get("gzipThreshold")));
+            }
+
+            return new ClientConfig(this);
+        }
+
+        /**
+         * Build an instance of {@code ClientConfig} from environment variables and/or system properties.
+         *
+         * @param env environment variables
+         * @param properties system properties
+         * @return the configuration for an {@code InfluxDBClient}.
+         */
+        @Nonnull
+        public ClientConfig build(@Nonnull final Map<String, String> env, final Properties properties) {
+            final BiFunction<String, String, String> get = (String name, String key) -> {
+                String envVar = env.get(name);
+                if (envVar != null) {
+                    return envVar;
+                }
+                if (properties != null) {
+                    return properties.getProperty(key);
+                }
+                return null;
+            };
+            this.host(get.apply("INFLUX_HOST", "influx.host"));
+            final String token = get.apply("INFLUX_TOKEN", "influx.token");
+            if (token != null) {
+                this.token(token.toCharArray());
+            }
+            final String org = get.apply("INFLUX_ORG", "influx.org");
+            if (org != null) {
+                this.organization(org);
+            }
+            final String database = get.apply("INFLUX_DATABASE", "influx.database");
+            if (database != null) {
+                this.database(database);
+            }
+
             return new ClientConfig(this);
         }
     }

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -462,7 +462,8 @@ public final class ClientConfig {
          * Build an instance of {@code ClientConfig} from connection string.
          *
          * @param connectionString connection string in URL format
-         * @return the configuration for an {@code InfluxDBClient}.
+         * @return the configuration for an {@code InfluxDBClient}
+         * @throws MalformedURLException when argument is not valid URL
          */
         @Nonnull
         public ClientConfig build(@Nonnull final String connectionString) throws MalformedURLException {

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -485,25 +485,7 @@ public final class ClientConfig {
                 this.database(parameters.get("database"));
             }
             if (parameters.containsKey("precision")) {
-                String value = parameters.get("precision");
-                WritePrecision precision;
-                switch (value) {
-                    case "ns":
-                        precision = WritePrecision.NS;
-                        break;
-                    case "us":
-                        precision = WritePrecision.US;
-                        break;
-                    case "ms":
-                        precision = WritePrecision.MS;
-                        break;
-                    case "s":
-                        precision = WritePrecision.S;
-                        break;
-                    default:
-                        throw new IllegalArgumentException(String.format("unsupported precision %s", value));
-                }
-                this.writePrecision(precision);
+                this.writePrecision(parsePrecision(parameters.get("precision")));
             }
             if (parameters.containsKey("gzipThreshold")) {
                 this.gzipThreshold(Integer.parseInt(parameters.get("gzipThreshold")));
@@ -544,8 +526,38 @@ public final class ClientConfig {
             if (database != null) {
                 this.database(database);
             }
+            final String precision = get.apply("INFLUX_PRECISION", "influx.precision");
+            if (precision != null) {
+                this.writePrecision(parsePrecision(precision));
+            }
+            final String gzipThreshold = get.apply("INFLUX_GZIP_THRESHOLD", "influx.gzipThreshold");
+            if (gzipThreshold != null) {
+                this.gzipThreshold(Integer.parseInt(gzipThreshold));
+            }
 
             return new ClientConfig(this);
+        }
+
+        private WritePrecision parsePrecision(@Nonnull final String precision) {
+            WritePrecision writePrecision;
+            switch (precision) {
+                case "ns":
+                    writePrecision = WritePrecision.NS;
+                    break;
+                case "us":
+                    writePrecision = WritePrecision.US;
+                    break;
+                case "ms":
+                    writePrecision = WritePrecision.MS;
+                    break;
+                case "s":
+                    writePrecision = WritePrecision.S;
+                    break;
+                default:
+                    throw new IllegalArgumentException(String.format("unsupported precision '%s'", precision));
+            }
+
+            return writePrecision;
         }
     }
 

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -64,7 +64,8 @@ class InfluxDBClientTest {
     @Test
     void fromConnectionString() throws Exception {
 
-        try (InfluxDBClient client = InfluxDBClient.getInstance("http://localhost:8086?token=my-token&database=my-db")) {
+        try (InfluxDBClient client = InfluxDBClient.getInstance("http://localhost:8086"
+                + "?token=my-token&database=my-db")) {
             Assertions.assertThat(client).isNotNull();
         }
     }

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -21,11 +21,10 @@
  */
 package com.influxdb.v3.client;
 
+import java.util.Properties;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.net.MalformedURLException;
-import java.util.Properties;
 
 class InfluxDBClientTest {
 
@@ -41,7 +40,7 @@ class InfluxDBClientTest {
     void requiredHostConnectionString() {
 
         Assertions.assertThatThrownBy(() -> InfluxDBClient.getInstance("?token=my-token&database=my-database"))
-                .isInstanceOf(MalformedURLException.class)
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("no protocol");
     }
 

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -73,14 +73,45 @@ class ClientConfigTest {
 
     @Test
     void fromConnectionString() throws MalformedURLException {
-        final ClientConfig cfg = new ClientConfig.Builder()
+        ClientConfig cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
-                        + "?token=my-token&org=my-org&database=my-database&precision=ms&gzipThreshold=128");
+                        + "?token=my-token&org=my-org&database=my-db&gzipThreshold=128");
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
         Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");
-        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo("my-db");
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS); // default
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(128);
+
+        cfg = new ClientConfig.Builder()
+                .build("http://localhost:9999/"
+                        + "?token=my-token&precision=us");
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo(null);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.US);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
+
+        cfg = new ClientConfig.Builder()
+                .build("http://localhost:9999/"
+                        + "?token=my-token&precision=ms");
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo(null);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
+
+        cfg = new ClientConfig.Builder()
+                .build("http://localhost:9999/"
+                        + "?token=my-token&precision=s");
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo(null);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.S);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
     }
 
     @Test
@@ -91,7 +122,7 @@ class ClientConfigTest {
                 "INFLUX_ORG", "my-org",
                 "INFLUX_DATABASE", "my-db"
         );
-        final ClientConfig cfg = new ClientConfig.Builder()
+        ClientConfig cfg = new ClientConfig.Builder()
                 .build(env, null);
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
@@ -109,7 +140,7 @@ class ClientConfigTest {
         properties.put("influx.token", "my-token");
         properties.put("influx.org", "my-org");
         properties.put("influx.database", "my-db");
-        final ClientConfig cfg = new ClientConfig.Builder()
+        ClientConfig cfg = new ClientConfig.Builder()
                 .build(new HashMap<>(), properties);
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -74,7 +74,8 @@ class ClientConfigTest {
     @Test
     void fromConnectionString() throws MalformedURLException {
         final ClientConfig cfg = new ClientConfig.Builder()
-                .build("http://localhost:9999/?token=my-token&org=my-org&database=my-database&precision=ms&gzipThreshold=128");
+                .build("http://localhost:9999/"
+                        + "?token=my-token&org=my-org&database=my-database&precision=ms&gzipThreshold=128");
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
         Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -116,13 +116,29 @@ class ClientConfigTest {
 
     @Test
     void fromEnv() {
-        final Map<String, String> env = Map.of(
+        // minimal
+        Map<String, String> env = Map.of(
+                "INFLUX_HOST", "http://localhost:9999/",
+                "INFLUX_TOKEN", "my-token"
+        );
+        ClientConfig cfg = new ClientConfig.Builder()
+                .build(env, null);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo(null);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
+        // these are defaults
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // simple
+        env = Map.of(
                 "INFLUX_HOST", "http://localhost:9999/",
                 "INFLUX_TOKEN", "my-token",
                 "INFLUX_ORG", "my-org",
                 "INFLUX_DATABASE", "my-db"
         );
-        ClientConfig cfg = new ClientConfig.Builder()
+        cfg = new ClientConfig.Builder()
                 .build(env, null);
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
@@ -131,16 +147,49 @@ class ClientConfigTest {
         // these are defaults
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // with write options
+        env = Map.of(
+                "INFLUX_HOST", "http://localhost:9999/",
+                "INFLUX_TOKEN", "my-token",
+                "INFLUX_ORG", "my-org",
+                "INFLUX_DATABASE", "my-db",
+                "INFLUX_PRECISION", "ms",
+                "INFLUX_GZIP_THRESHOLD", "64"
+        );
+        cfg = new ClientConfig.Builder()
+                .build(env, null);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo("my-db");
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
     }
 
     @Test
     void fromSystemProperties() {
-        final Properties properties = new Properties();
+        // minimal
+        Properties properties = new Properties();
+        properties.put("influx.host", "http://localhost:9999/");
+        properties.put("influx.token", "my-token");
+        ClientConfig cfg = new ClientConfig.Builder()
+                .build(new HashMap<>(), properties);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo(null);
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
+        // these are defaults
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // simple
+        properties = new Properties();
         properties.put("influx.host", "http://localhost:9999/");
         properties.put("influx.token", "my-token");
         properties.put("influx.org", "my-org");
         properties.put("influx.database", "my-db");
-        ClientConfig cfg = new ClientConfig.Builder()
+        cfg = new ClientConfig.Builder()
                 .build(new HashMap<>(), properties);
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
@@ -149,5 +198,22 @@ class ClientConfigTest {
         // these are defaults
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // with write options
+        properties = new Properties();
+        properties.put("influx.host", "http://localhost:9999/");
+        properties.put("influx.token", "my-token");
+        properties.put("influx.org", "my-org");
+        properties.put("influx.database", "my-db");
+        properties.put("influx.precision", "ms");
+        properties.put("influx.gzipThreshold", "64");
+        cfg = new ClientConfig.Builder()
+                .build(new HashMap<>(), properties);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");
+        Assertions.assertThat(cfg.getDatabase()).isEqualTo("my-db");
+        Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
+        Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
     }
 }


### PR DESCRIPTION
Closes #

## Proposed Changes

This PR adds support to create Client from
* connection string _eg. https://us-east-1-1.aws.cloud2.influxdata.com?token=my-token&database=my-database_
  Supported parameters: 
  * `token`
  * `org`
  * `database`
  * `precision`
  * `gzipThreshold`
* environment variables - same names/style as Influx CLI
  * `INFLUX_HOST`
  * `INFLUX_TOKEN`
  * `INFLUX_ORG`
  * `INFLUX_DATABASE`
  * `INFLUX_PRECISION`
  * `INFLUX_GZIP_THRESHOLD`
* system properties (environment variables take precedence)
  * `influx.host`
  * `influx.token`
  * `influx.org`
  * `influx.database`
  * `influx.precision`
  * `influx.gzipThreshold`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
