### PR TITLE
fix: iteration over more Arrow streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.4.0 [unreleased]
 
+### Bug Fixes
+
+1. [#55](https://github.com/InfluxCommunity/influxdb3-java/pull/55): Iteration over more Arrow streams
+
 ## 0.3.0 [2023-10-02]
 
 ### Features


### PR DESCRIPTION
Closes #54

## Proposed Changes

Fixed iterating over more `VectorSchemaRoot` which can be caused by "group" expression.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
