### PR TITLE
feat: starts defaultTags used when writing points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.5.0 [unreleased]
 
+### Features
+
+1. [#78](https://github.com/InfluxCommunity/influxdb3-java/pull/78): Default Tags can be used when writing points.
+
 ### Bug Fixes
 
 1. [#77](https://github.com/InfluxCommunity/influxdb3-java/pull/77): Serialize InfluxDB response to `PointValues`

--- a/pom.xml
+++ b/pom.xml
@@ -432,9 +432,6 @@
                         <version>${junit-jupiter.version}</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,9 @@
                         <version>${junit-jupiter.version}</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -23,6 +23,7 @@ package com.influxdb.v3.client;
 
 import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -228,6 +229,32 @@ public interface InfluxDBClient extends AutoCloseable {
                 .token(token)
                 .database(database)
                 .build();
+
+        return getInstance(config);
+    }
+
+    /**
+     * Creates a new instance of the {@link InfluxDBClient} for interacting with an InfluxDB server, simplifying
+     * common operations such as writing, querying.
+     *
+     * @param host the URL of the InfluxDB server
+     * @param token the authentication token for accessing the InfluxDB server, can be null
+     * @param database  the database to be used for InfluxDB operations, can be null
+     * @param defaultTags tags to be added by default to writes of points
+     * @return new instance of the {@link InfluxDBClient}
+     */
+    @Nonnull
+    static InfluxDBClient getInstance(@Nonnull final String host,
+                                      @Nullable final char[] token,
+                                      @Nullable final String database,
+                                      @Nullable Map<String, String> defaultTags) {
+
+        ClientConfig config = new ClientConfig.Builder()
+          .host(host)
+          .token(token)
+          .database(database)
+          .defaultTags(defaultTags)
+          .build();
 
         return getInstance(config);
     }

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -159,8 +159,8 @@ public final class ClientConfig {
     }
 
     /**
-     * Gets default tags used when writing points
-     * @return
+     * Gets default tags used when writing points.
+     * @return default tags
      */
     public Map<String, String> getDefaultTags() {
         return defaultTags;

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -49,6 +49,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>organization</code> - organization to be used for operations</li>
  *     <li><code>database</code> - database to be used for InfluxDB operations</li>
  *     <li><code>writePrecision</code> - precision to use when writing points to InfluxDB</li>
+ *     <li><code>defaultTags</code> - defaultTags added when writing points to InfluxDB</li>
  *     <li><code>gzipThreshold</code> - threshold when gzip compression is used for writing points to InfluxDB</li>
  *     <li><code>responseTimeout</code> - timeout when connecting to InfluxDB</li>
  *     <li><code>allowHttpRedirects</code> - allow redirects for InfluxDB connections</li>
@@ -89,6 +90,7 @@ public final class ClientConfig {
     private final String database;
     private final WritePrecision writePrecision;
     private final Integer gzipThreshold;
+    private final Map<String, String> defaultTags;
     private final Duration timeout;
     private final Boolean allowHttpRedirects;
     private final Boolean disableServerCertificateValidation;
@@ -154,6 +156,14 @@ public final class ClientConfig {
     @Nonnull
     public Integer getGzipThreshold() {
         return gzipThreshold;
+    }
+
+    /**
+     * Gets default tags used when writing points
+     * @return
+     */
+    public Map<String, String> getDefaultTags() {
+        return defaultTags;
     }
 
     /**
@@ -240,6 +250,7 @@ public final class ClientConfig {
                 && Objects.equals(database, that.database)
                 && writePrecision == that.writePrecision
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
+                && Objects.equals(defaultTags, that.defaultTags)
                 && Objects.equals(timeout, that.timeout)
                 && Objects.equals(allowHttpRedirects, that.allowHttpRedirects)
                 && Objects.equals(disableServerCertificateValidation, that.disableServerCertificateValidation)
@@ -268,6 +279,7 @@ public final class ClientConfig {
                 .add("proxy=" + proxy)
                 .add("authenticator=" + authenticator)
                 .add("headers=" + headers)
+                .add("defaultTags=" + defaultTags)
                 .toString();
     }
 
@@ -283,6 +295,7 @@ public final class ClientConfig {
         private String database;
         private WritePrecision writePrecision;
         private Integer gzipThreshold;
+        private Map<String, String> defaultTags;
         private Duration timeout;
         private Boolean allowHttpRedirects;
         private Boolean disableServerCertificateValidation;
@@ -367,6 +380,19 @@ public final class ClientConfig {
         public Builder gzipThreshold(@Nullable final Integer gzipThreshold) {
 
             this.gzipThreshold = gzipThreshold;
+            return this;
+        }
+
+        /**
+         * Sets default tags to be written with points.
+         *
+         * @param defaultTags - tags to be used.
+         * @return this
+         */
+        @Nonnull
+        public Builder defaultTags(@Nullable final Map<String, String> defaultTags) {
+
+            this.defaultTags = defaultTags;
             return this;
         }
 
@@ -569,6 +595,7 @@ public final class ClientConfig {
         database = builder.database;
         writePrecision = builder.writePrecision != null ? builder.writePrecision : WritePrecision.NS;
         gzipThreshold = builder.gzipThreshold != null ? builder.gzipThreshold : 1000;
+        defaultTags = builder.defaultTags;
         timeout = builder.timeout != null ? builder.timeout : Duration.ofSeconds(10);
         allowHttpRedirects = builder.allowHttpRedirects != null ? builder.allowHttpRedirects : false;
         disableServerCertificateValidation = builder.disableServerCertificateValidation != null

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -261,8 +261,11 @@ public final class ClientConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, Arrays.hashCode(token), organization, database, writePrecision, gzipThreshold,
-                timeout, allowHttpRedirects, disableServerCertificateValidation, proxy, authenticator, headers);
+        return Objects.hash(host, Arrays.hashCode(token), organization,
+          database, writePrecision, gzipThreshold,
+          timeout, allowHttpRedirects, disableServerCertificateValidation,
+          proxy, authenticator, headers,
+          defaultTags);
     }
 
     @Override

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -220,10 +220,15 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
             put("precision", precision.name().toLowerCase());
         }};
 
+        Map<String, String> defaultTags = options.defaultTagsSafe(config);
+
         String lineProtocol = data.stream().map(item -> {
                     if (item == null) {
                         return null;
                     } else if (item instanceof Point) {
+                        for (String key : defaultTags.keySet()) {
+                            ((Point) item).setTag(key, defaultTags.get(key));
+                        }
                         return ((Point) item).toLineProtocol();
                     } else {
                         return item.toString();

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -217,7 +217,7 @@ public final class WriteOptions {
         }
 
         /**
-         * Sets defaultTags
+         * Sets defaultTags.
          *
          * @param defaultTags to be used when writing points
          * @return this

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -127,8 +127,12 @@ public final class WriteOptions {
     @Nonnull
     public Map<String, String> defaultTagsSafe(@Nonnull final ClientConfig config) {
         Arguments.checkNotNull(config, "config");
-        return defaultTags.size() > 0 ? defaultTags
-          : (config.getDefaultTags() != null ? config.getDefaultTags() : defaultTags);
+        return defaultTags.isEmpty()
+          ? (config.getDefaultTags() != null
+              ? config.getDefaultTags()
+              : defaultTags
+            )
+          : defaultTags;
     }
 
     /**

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -21,6 +21,8 @@
  */
 package com.influxdb.v3.client.write;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -36,7 +38,8 @@ import com.influxdb.v3.client.internal.Arguments;
  * <ul>
  *     <li><code>database</code> - specifies the database to be used for InfluxDB operations</li>
  *     <li><code>organization</code> - specifies the organization to be used for InfluxDB operations</li>
- *     <li><code>precision</code> - specified the precision to use for the timestamp of points</li>
+ *     <li><code>precision</code> - specifies the precision to use for the timestamp of points</li>
+ *     <li><code>defaultTags</code> - specifies tags to be added by default to all write operations using points.</li>
  * </ul>
  */
 @ThreadSafe
@@ -59,6 +62,7 @@ public final class WriteOptions {
     private final String database;
     private final WritePrecision precision;
     private final Integer gzipThreshold;
+    private final Map<String, String> defaultTags;
 
     /**
      * Construct WriteAPI options.
@@ -73,7 +77,27 @@ public final class WriteOptions {
         this.database = database;
         this.precision = precision;
         this.gzipThreshold = gzipThreshold;
+        this.defaultTags = new HashMap<>();
     }
+
+    /**
+     * Construct WriteAPI options.
+     *
+     * @param database     The database to be used for InfluxDB operations.
+     * @param precision    The precision to use for the timestamp of points.
+     * @param gzipThreshold The threshold for compressing request body.
+     * @param defaultTags   Default tags to be added when writing points.
+     */
+    public WriteOptions(@Nonnull final String database,
+                        @Nonnull final WritePrecision precision,
+                        @Nonnull final Integer gzipThreshold,
+                        @Nonnull final Map<String, String> defaultTags) {
+        this.database = database;
+        this.precision = precision;
+        this.gzipThreshold = gzipThreshold;
+        this.defaultTags = defaultTags;
+    }
+
 
     /**
      * @param config with default value
@@ -94,6 +118,17 @@ public final class WriteOptions {
         Arguments.checkNotNull(config, "config");
         return precision != null ? precision
                 : (config.getWritePrecision() != null ? config.getWritePrecision() : DEFAULT_WRITE_PRECISION);
+    }
+
+    /**
+     * @param config with/without defaultTags defined
+     * @return defaultTags - can be an empty map if none are defined.
+     */
+    @Nonnull
+    public Map<String, String> defaultTagsSafe(@Nonnull final ClientConfig config) {
+        Arguments.checkNotNull(config, "config");
+        return defaultTags.size() > 0 ? defaultTags
+          : (config.getDefaultTags() != null ? config.getDefaultTags() : defaultTags);
     }
 
     /**
@@ -118,12 +153,13 @@ public final class WriteOptions {
         WriteOptions that = (WriteOptions) o;
         return Objects.equals(database, that.database)
                 && precision == that.precision
-                && Objects.equals(gzipThreshold, that.gzipThreshold);
+                && Objects.equals(gzipThreshold, that.gzipThreshold)
+                && defaultTags.equals(that.defaultTags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(database, precision, gzipThreshold);
+        return Objects.hash(database, precision, gzipThreshold, defaultTags);
     }
 
     private boolean isNotDefined(final String option) {
@@ -139,6 +175,7 @@ public final class WriteOptions {
         private String database;
         private WritePrecision precision;
         private Integer gzipThreshold;
+        private Map<String, String> defaultTags = new HashMap<>();
 
         /**
          * Sets the database.
@@ -180,6 +217,18 @@ public final class WriteOptions {
         }
 
         /**
+         * Sets defaultTags
+         *
+         * @param defaultTags to be used when writing points
+         * @return this
+         */
+        @Nonnull
+        public Builder defaultTags(@Nonnull final Map<String, String> defaultTags) {
+            this.defaultTags = defaultTags;
+            return this;
+        }
+
+        /**
          * Build an instance of {@code ClientConfig}.
          *
          * @return the configuration for an {@code InfluxDBClient}.
@@ -195,5 +244,6 @@ public final class WriteOptions {
         this.database = builder.database;
         this.precision = builder.precision;
         this.gzipThreshold = builder.gzipThreshold;
+        this.defaultTags = builder.defaultTags;
     }
 }

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -100,8 +100,5 @@ class InfluxDBClientTest {
           defaultTags)) {
             Assertions.assertThat(client).isNotNull();
         }
-
-
-
     }
 }

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -93,13 +93,13 @@ class InfluxDBClientTest {
 
         Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
 
-        try(InfluxDBClient client = InfluxDBClient.getInstance(
+        try (InfluxDBClient client = InfluxDBClient.getInstance(
           "http://localhost:8086",
           "MY-TOKEN".toCharArray(),
           "MY-DATABASE",
-          defaultTags)){
+          defaultTags)) {
             Assertions.assertThat(client).isNotNull();
-        };
+        }
 
 
 

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -21,6 +21,7 @@
  */
 package com.influxdb.v3.client;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.assertj.core.api.Assertions;
@@ -85,5 +86,22 @@ class InfluxDBClientTest {
         } finally {
             System.setProperties(old);
         }
+    }
+
+    @Test
+    void withDefaultTags() throws Exception {
+
+        Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
+
+        try(InfluxDBClient client = InfluxDBClient.getInstance(
+          "http://localhost:8086",
+          "MY-TOKEN".toCharArray(),
+          "MY-DATABASE",
+          defaultTags)){
+            Assertions.assertThat(client).isNotNull();
+        };
+
+
+
     }
 }

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -59,8 +59,13 @@ class ClientConfigTest {
     void hashConfig() {
         ClientConfig config = configBuilder.build();
 
+        Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
+
         Assertions.assertThat(config.hashCode()).isEqualTo(configBuilder.build().hashCode());
-        Assertions.assertThat(config.hashCode()).isNotEqualTo(configBuilder.database("database").build().hashCode());
+        Assertions.assertThat(config.hashCode())
+          .isNotEqualTo(configBuilder.database("database").build().hashCode());
+        Assertions.assertThat(config.hashCode())
+          .isNotEqualTo(configBuilder.defaultTags(defaultTags).build().hashCode());
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -182,6 +182,34 @@ class WriteOptionsTest {
     }
 
     @Test
+    void optionsOverridesEmptyDefaultTags() {
+
+        Map<String, String> defaultTags = new HashMap<>() {{
+            put("model", "train");
+            put("scale", "HO");
+        }};
+
+        ClientConfig config = configBuilder
+          .database("my-database")
+          .organization("my-org")
+          .writePrecision(WritePrecision.S)
+          .gzipThreshold(512)
+          .defaultTags(defaultTags)
+          .build();
+
+        Assertions.assertThat(config.getDefaultTags()).isEqualTo(defaultTags);
+
+        WriteOptions options = new WriteOptions.Builder().build();
+
+        Assertions.assertThat(options.databaseSafe(config)).isEqualTo("my-database");
+        Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WritePrecision.S);
+        Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(512);
+        Assertions.assertThat(options.defaultTagsSafe(config)).isEqualTo(defaultTags);
+
+
+    }
+
+    @Test
     void optionsHashCode() {
 
         Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -54,7 +54,7 @@ class WriteOptionsTest {
     }
 
     @Test
-    void optionsWithDefaultTags(){
+    void optionsWithDefaultTags() {
         Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
 
         WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512, defaultTags);

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -54,6 +54,22 @@ class WriteOptionsTest {
     }
 
     @Test
+    void optionsWithDefaultTags(){
+        Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
+
+        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512, defaultTags);
+        WriteOptions optionsViaBuilder = new WriteOptions.Builder()
+          .database("my-database")
+          .precision(WritePrecision.S)
+          .gzipThreshold(512)
+          .defaultTags(defaultTags)
+          .build();
+
+        Assertions.assertThat(options).isEqualTo(optionsViaBuilder);
+
+    }
+
+    @Test
     void optionsEmpty() {
         ClientConfig config = configBuilder
                 .database("my-database")

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -180,4 +180,19 @@ class WriteOptionsTest {
         Assertions.assertThat(options.defaultTagsSafe(config)).isEqualTo(defaultTagsNew);
 
     }
+
+    @Test
+    void optionsHashCode() {
+
+        Map<String, String> defaultTags = Map.of("unit", "U2", "model", "M1");
+
+        WriteOptions.Builder builder = new WriteOptions.Builder();
+        WriteOptions baseOptions = builder.build();
+
+        Assertions.assertThat(baseOptions.hashCode())
+          .isNotEqualTo(builder.database("my-database").build().hashCode());
+        Assertions.assertThat(baseOptions.hashCode())
+          .isNotEqualTo(builder.defaultTags(defaultTags).build().hashCode());
+
+    }
 }

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -21,11 +21,16 @@
  */
 package com.influxdb.v3.client.write;
 
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.influxdb.v3.client.config.ClientConfig;
+
 
 class WriteOptionsTest {
 
@@ -126,5 +131,37 @@ class WriteOptionsTest {
         Assertions.assertThat(options.databaseSafe(config)).isEqualTo("my-database");
         Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WritePrecision.S);
         Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(4096);
+    }
+
+    @Test
+    void optionsOverridesDefaultTags() {
+        Map<String, String> defaultTagsBase = new HashMap<>() {{
+            put("model", "train");
+            put("scale", "HO");
+        }};
+
+        Map<String, String> defaultTagsNew = new HashMap<>() {{
+            put("unit", "D1");
+        }};
+
+        ClientConfig config = configBuilder
+          .database("my-database")
+          .organization("my-org")
+          .writePrecision(WritePrecision.S)
+          .gzipThreshold(512)
+          .defaultTags(defaultTagsBase)
+          .build();
+
+        Assertions.assertThat(config.getDefaultTags()).isEqualTo(defaultTagsBase);
+
+        WriteOptions options = new WriteOptions.Builder()
+          .defaultTags(defaultTagsNew)
+          .build();
+
+        Assertions.assertThat(options.databaseSafe(config)).isEqualTo("my-database");
+        Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WritePrecision.S);
+        Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(512);
+        Assertions.assertThat(options.defaultTagsSafe(config)).isEqualTo(defaultTagsNew);
+
     }
 }


### PR DESCRIPTION
Closes #

## Proposed Changes

Adds default tags to ClientConfig and WriteOptions and then leverages them when writing points.  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
