### PR TITLE
feat: add SQL query with named parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 1. [#94](https://github.com/InfluxCommunity/influxdb3-java/pull/94): Add support for named query parameters
 
-
 ## 0.5.1 [2024-02-01]
 
 Resync artifacts with Maven Central.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.6.0 [unreleased]
 
+### Features
+
+1. [#94](https://github.com/InfluxCommunity/influxdb3-java/pull/94): Add support for named query parameters
+
+
 ## 0.5.1 [2024-02-01]
 
 Resync artifacts with Maven Central.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ try (Stream<Object[]> stream = client.query(sql)) {
 System.out.printf("--------------------------------------------------------%n%n");
 
 //
+// Query by parametrized SQL
+//
+System.out.printf("--------------------Parametrized SQL--------------------%n");
+System.out.printf("| %-8s | %-8s | %-30s |%n", "location", "value", "time");
+System.out.printf("--------------------------------------------------------%n");
+
+String sqlParams = "select time,location,value from temperature where location=$location order by time desc limit 10";
+try (Stream<Object[]> stream = client.query(sqlParams, Map.of("location", "north"))) {
+    stream.forEach(row -> System.out.printf("| %-8s | %-8s | %-30s |%n", row[1], row[2], row[0]));
+}
+
+System.out.printf("--------------------------------------------------------%n%n");
+
+//
 // Query by InfluxQL
 //
 System.out.printf("-----------------------------------------%n");

--- a/examples/src/main/java/com/influxdb/v3/IOxExample.java
+++ b/examples/src/main/java/com/influxdb/v3/IOxExample.java
@@ -22,6 +22,7 @@
 package com.influxdb.v3;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import com.influxdb.v3.client.InfluxDBClient;
@@ -68,6 +69,20 @@ public final class IOxExample {
 
             String sql = "select time,location,value from temperature order by time desc limit 10";
             try (Stream<Object[]> stream = client.query(sql)) {
+                stream.forEach(row -> System.out.printf("| %-8s | %-8s | %-30s |%n", row[1], row[2], row[0]));
+            }
+
+            System.out.printf("--------------------------------------------------------%n%n");
+
+            //
+            // Query by parametrized SQL
+            //
+            System.out.printf("--------------------------------------------------------%n");
+            System.out.printf("| %-8s | %-8s | %-30s |%n", "location", "value", "time");
+            System.out.printf("--------------------------------------------------------%n");
+
+            String sqlWithParameters = "select time,location,value from temperature where location=$location order by time desc limit 10";
+            try (Stream<Object[]> stream = client.query(sqlWithParameters, Map.of("location", "north"))) {
                 stream.forEach(row -> System.out.printf("| %-8s | %-8s | %-30s |%n", row[1], row[2], row[0]));
             }
 

--- a/examples/src/main/java/com/influxdb/v3/IOxExample.java
+++ b/examples/src/main/java/com/influxdb/v3/IOxExample.java
@@ -81,7 +81,8 @@ public final class IOxExample {
             System.out.printf("| %-8s | %-8s | %-30s |%n", "location", "value", "time");
             System.out.printf("--------------------------------------------------------%n");
 
-            String sqlWithParameters = "select time,location,value from temperature where location=$location order by time desc limit 10";
+            String sqlWithParameters =
+                    "select time,location,value from temperature where location=$location order by time desc limit 10";
             try (Stream<Object[]> stream = client.query(sqlWithParameters, Map.of("location", "north"))) {
                 stream.forEach(row -> System.out.printf("| %-8s | %-8s | %-30s |%n", row[1], row[2], row[0]));
             }

--- a/examples/src/main/java/com/influxdb/v3/IOxExample.java
+++ b/examples/src/main/java/com/influxdb/v3/IOxExample.java
@@ -77,7 +77,7 @@ public final class IOxExample {
             //
             // Query by parametrized SQL
             //
-            System.out.printf("--------------------------------------------------------%n");
+            System.out.printf("--------------------Parametrized SQL--------------------%n");
             System.out.printf("| %-8s | %-8s | %-30s |%n", "location", "value", "time");
             System.out.printf("--------------------------------------------------------%n");
 

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -125,6 +125,26 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
      * <pre>
+     * try (Stream&lt;Object[]&gt; rows = client.query("select * from cpu where host=$host",
+     *                                                 Map.of("host", "server-a")) {
+     *      rows.forEach(row -&gt; {
+     *          // process row
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @return Batches of rows returned by the query
+     */
+    @Nonnull
+    Stream<Object[]> query(@Nonnull final String query, @Nonnull final Map<String, Object> parameters);
+
+    /**
+     * Query data from InfluxDB IOx using FlightSQL.
+     * <p>
+     * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
+     * <pre>
      * try (Stream&lt;Object[]&gt; rows = client.query("select * from cpu", options)) {
      *      rows.forEach(row -&gt; {
      *          // process row
@@ -138,6 +158,29 @@ public interface InfluxDBClient extends AutoCloseable {
      */
     @Nonnull
     Stream<Object[]> query(@Nonnull final String query, @Nonnull final QueryOptions options);
+
+    /**
+     * Query data from InfluxDB IOx using FlightSQL.
+     * <p>
+     * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
+     * <pre>
+     * try (Stream&lt;Object[]&gt; rows = client.query("select * from cpu where host=$host",
+     *                                                 Map.of("host", "server-a"), options)) {
+     *      rows.forEach(row -&gt; {
+     *          // process row
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query      the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @param options the options for querying data from InfluxDB
+     * @return Batches of rows returned by the query
+     */
+    @Nonnull
+    Stream<Object[]> query(@Nonnull final String query,
+                           @Nonnull final Map<String, Object> parameters,
+                           @Nonnull final QueryOptions options);
 
     /**
      * Query data from InfluxDB IOx into Point structure using FlightSQL.
@@ -162,6 +205,26 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
      * <pre>
+     * try (Stream&lt;PointValues&gt; rows = client.queryPoints("select * from cpu where host=$host",
+     *                                                          Map.of("host", "server-a"))) {
+     *      rows.forEach(row -&gt; {
+     *          // process row
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query      the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @return Batches of PointValues returned by the query
+     */
+    @Nonnull
+    Stream<PointValues> queryPoints(@Nonnull final String query, @Nonnull final Map<String, Object> parameters);
+
+    /**
+     * Query data from InfluxDB IOx into Point structure using FlightSQL.
+     * <p>
+     * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
+     * <pre>
      * try (Stream&lt;PointValues&gt; rows = client.queryPoints("select * from cpu", options)) {
      *      rows.forEach(row -&gt; {
      *          // process row
@@ -175,6 +238,30 @@ public interface InfluxDBClient extends AutoCloseable {
      */
     @Nonnull
     Stream<PointValues> queryPoints(@Nonnull final String query, @Nonnull final QueryOptions options);
+
+    /**
+     * Query data from InfluxDB IOx into Point structure using FlightSQL.
+     * <p>
+     * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
+     * <pre>
+     * try (Stream&lt;PointValues&gt; rows = client.queryPoints("select * from cpu where host=$host",
+     *                                                          Map.of("host", "server-a"),
+     *                                                          options)) {
+     *      rows.forEach(row -&gt; {
+     *          // process row
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query      the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @param options the options for querying data from InfluxDB
+     * @return Batches of PointValues returned by the query
+     */
+    @Nonnull
+    Stream<PointValues> queryPoints(@Nonnull final String query,
+                                    @Nonnull final Map<String, Object> parameters,
+                                    @Nonnull final QueryOptions options);
 
     /**
      * Query data from InfluxDB IOx using FlightSQL.
@@ -196,6 +283,26 @@ public interface InfluxDBClient extends AutoCloseable {
 
     /**
      * Query data from InfluxDB IOx using FlightSQL.
+     * <p>
+     * The result stream should be closed after use, you can use try-resource pattern to close it automatically:
+     * <pre>
+     * try (Stream&lt;VectorSchemaRoot&gt; batches = client.queryBatches("select * from cpu where host=$host",
+     *                                                                   Map.of("host", "server-a"))) {
+     *      batches.forEach(batch -&gt; {
+     *          // process batch
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @return Batches of rows returned by the query
+     */
+    @Nonnull
+    Stream<VectorSchemaRoot> queryBatches(@Nonnull final String query, @Nonnull final Map<String, Object> parameters);
+
+    /**
+     * Query data from InfluxDB IOx using FlightSQL.
      * <pre>
      * try (Stream&lt;VectorSchemaRoot&gt; batches = client.queryBatches("select * from cpu", options)) {
      *      batches.forEach(batch -&gt; {
@@ -210,6 +317,28 @@ public interface InfluxDBClient extends AutoCloseable {
      */
     @Nonnull
     Stream<VectorSchemaRoot> queryBatches(@Nonnull final String query, @Nonnull final QueryOptions options);
+
+    /**
+     * Query data from InfluxDB IOx using FlightSQL.
+     * <pre>
+     * try (Stream&lt;VectorSchemaRoot&gt; batches = client.queryBatches("select * from cpu where host=$host",
+     *                                                                   Map.of("host", "server-a"),
+     *                                                                   options)) {
+     *      batches.forEach(batch -&gt; {
+     *          // process batch
+     *      }
+     * });
+     * </pre>
+     *
+     * @param query      the SQL query string to execute, cannot be null
+     * @param parameters query named parameters
+     * @param options the options for querying data from InfluxDB
+     * @return Batches of rows returned by the query
+     */
+    @Nonnull
+    Stream<VectorSchemaRoot> queryBatches(@Nonnull final String query,
+                                          @Nonnull final Map<String, Object> parameters,
+                                          @Nonnull final QueryOptions options);
 
     /**
      * Creates a new instance of the {@link InfluxDBClient} for interacting with an InfluxDB server, simplifying

--- a/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
@@ -91,13 +91,18 @@ final class FlightSqlClient implements AutoCloseable {
     @Nonnull
     Stream<VectorSchemaRoot> execute(@Nonnull final String query,
                                      @Nonnull final String database,
-                                     @Nonnull final QueryType queryType) {
+                                     @Nonnull final QueryType queryType,
+                                     @Nonnull final Map<String, Object> queryParameters) {
 
-        Map<String, String> ticketData = new HashMap<>() {{
+        Map<String, Object> ticketData = new HashMap<>() {{
             put("database", database);
             put("sql_query", query);
             put("query_type", queryType.name().toLowerCase());
         }};
+
+        if (queryParameters.size() > 0) {
+            ticketData.put("params", queryParameters);
+        }
 
         String json;
         try {

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -64,7 +64,7 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
             + "or use default configuration at 'ClientConfig.database'.";
 
     private static final Map<String, Object> NO_PARAMETERS = Map.of();
-    private static final List<Class> ALLOWED_NAMED_PARAMETER_TYPES = List.of(
+    private static final List<Class<?>> ALLOWED_NAMED_PARAMETER_TYPES = List.of(
             String.class,
             Integer.class,
             Long.class,

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -219,7 +219,7 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
     @Nonnull
     @Override
     public Stream<VectorSchemaRoot> queryBatches(@Nonnull final String query) {
-        return queryBatches(query, NO_PARAMETERS, QueryOptions.DEFAULTS);
+        return queryBatches(query, QueryOptions.DEFAULTS);
     }
 
     @Nonnull

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -186,7 +186,7 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
     @Nonnull
     @Override
     public Stream<PointValues> queryPoints(@Nonnull final String query) {
-        return queryPoints(query, NO_PARAMETERS, QueryOptions.DEFAULTS);
+        return queryPoints(query, QueryOptions.DEFAULTS);
     }
 
     @Nonnull

--- a/src/test/java/com/influxdb/v3/client/ITQueryWrite.java
+++ b/src/test/java/com/influxdb/v3/client/ITQueryWrite.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -59,7 +60,7 @@ class ITQueryWrite {
         client = getInstance();
 
         String measurement = "integration_test";
-        int testId = (int) System.currentTimeMillis();
+        long testId = System.currentTimeMillis();
         client.writeRecord(measurement + ",type=used value=123.0,testId=" + testId);
 
         String sql = String.format("SELECT value FROM %s WHERE \"testId\"=%d", measurement, testId);
@@ -124,7 +125,7 @@ class ITQueryWrite {
                 .build());
 
         String measurement = "integration_test";
-        int testId = (int) System.currentTimeMillis();
+        long testId = System.currentTimeMillis();
         client.writeRecord(measurement + ",type=used value=123.0,testId=" + testId);
 
         String sql = String.format("SELECT value FROM %s WHERE \"testId\"=%d", measurement, testId);
@@ -132,6 +133,30 @@ class ITQueryWrite {
             stream.forEach(row -> {
                 Assertions.assertThat(row).hasSize(1);
                 Assertions.assertThat(row[0]).isEqualTo(123.0);
+            });
+        }
+    }
+
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_URL", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_TOKEN", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_DATABASE", matches = ".*")
+    @Test
+    void queryWriteParameters() {
+        client = InfluxDBClient.getInstance(new ClientConfig.Builder()
+                .host(System.getenv("TESTING_INFLUXDB_URL"))
+                .token(System.getenv("TESTING_INFLUXDB_TOKEN").toCharArray())
+                .database(System.getenv("TESTING_INFLUXDB_DATABASE"))
+                .build());
+
+        String measurement = "integration_test";
+        long testId = System.currentTimeMillis();
+        client.writeRecord(measurement + ",type=used value=124.0,testId=" + testId);
+
+        String sql = String.format("SELECT value FROM %s WHERE \"testId\"=$id", measurement);
+        try (Stream<Object[]> stream = client.query(sql, Map.of("id", testId))) {
+            stream.forEach(row -> {
+                Assertions.assertThat(row).hasSize(1);
+                Assertions.assertThat(row[0]).isEqualTo(124.0);
             });
         }
     }

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -101,4 +101,19 @@ class InfluxDBClientTest {
             Assertions.assertThat(client).isNotNull();
         }
     }
+
+    @Test
+    public void unsupportedQueryParams() throws Exception {
+        try (InfluxDBClient client = InfluxDBClient.getInstance("http://localhost:8086",
+                "my-token".toCharArray(), "my-database")) {
+
+            String query = "select * from cpu where client=$client";
+            Map<String, Object> parameters = Map.of("client", client);
+
+            Assertions.assertThatThrownBy(() -> client.queryPoints(query, parameters))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("The parameter client value has unsupported type: "
+                            + "class com.influxdb.v3.client.internal.InfluxDBClientImpl");
+        }
+    }
 }


### PR DESCRIPTION
## Proposed Changes

This PR add supports for named parameters in the query API:

```java
try (Stream<PointValues> rows = client.queryPoints(
    "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
    Map.of(
      "id", 1,
      "name", "test"
    )
);
```


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
