### PR TITLE
feat: user-agent header is added by default for gRPC and Rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.8.0 [unreleased]
 
-### Features 
+### Features
 
 1. [#144](https://github.com/InfluxCommunity/influxdb3-java/pull/133): user-agent header is updated for both REST and gRPC calls.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.8.0 [unreleased]
 
+### Features 
+
+1. [#144](https://github.com/InfluxCommunity/influxdb3-java/pull/133): user-agent header is updated for both REST and gRPC calls.
+
 ## 0.7.0 [2024-03-11]
 
 ### Features

--- a/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
@@ -76,9 +76,14 @@ final class FlightSqlClient implements AutoCloseable {
         if (config.getToken() != null && config.getToken().length > 0) {
             defaultHeaders.put("Authorization", "Bearer " + new String(config.getToken()));
         }
+
+        defaultHeaders.put("User-Agent", Identity.getUserAgent());
+
         if (config.getHeaders() != null) {
             defaultHeaders.putAll(config.getHeaders());
         }
+
+        Package mainPackage = RestClient.class.getPackage();
 
         this.client = (client != null) ? client : createFlightClient(config);
     }

--- a/src/main/java/com/influxdb/v3/client/internal/Identity.java
+++ b/src/main/java/com/influxdb/v3/client/internal/Identity.java
@@ -1,0 +1,26 @@
+package com.influxdb.v3.client.internal;
+
+/**
+ * Functions for establishing caller identity.
+ */
+public final class Identity {
+  private Identity() { }
+
+  /**
+   * Attempt to get the package version.
+   * @return - package version or unknown.
+   */
+  public static String getVersion() {
+    Package mainPackage = Identity.class.getPackage();
+    String version = mainPackage != null ? mainPackage.getImplementationVersion() : "unknown";
+    return version == null ? "unknown" : version;
+  }
+
+  /**
+   * Get a standard user-agent identity to be used in all HTTP based calls.
+   * @return - the standard user-agent string.
+   */
+  public static String getUserAgent() {
+    return String.format("influxdb3-java:%s", getVersion());
+  }
+}

--- a/src/main/java/com/influxdb/v3/client/internal/Identity.java
+++ b/src/main/java/com/influxdb/v3/client/internal/Identity.java
@@ -24,14 +24,14 @@ package com.influxdb.v3.client.internal;
 /**
  * Functions for establishing caller identity.
  */
-public final class Identity {
+final class Identity {
   private Identity() { }
 
   /**
    * Attempt to get the package version.
    * @return - package version or unknown.
    */
-  public static String getVersion() {
+  static String getVersion() {
     Package mainPackage = Identity.class.getPackage();
     String version = mainPackage != null ? mainPackage.getImplementationVersion() : "unknown";
     return version == null ? "unknown" : version;
@@ -41,7 +41,7 @@ public final class Identity {
    * Get a standard user-agent identity to be used in all HTTP based calls.
    * @return - the standard user-agent string.
    */
-  public static String getUserAgent() {
+  static String getUserAgent() {
     return String.format("influxdb3-java/%s", getVersion());
   }
 }

--- a/src/main/java/com/influxdb/v3/client/internal/Identity.java
+++ b/src/main/java/com/influxdb/v3/client/internal/Identity.java
@@ -42,6 +42,6 @@ public final class Identity {
    * @return - the standard user-agent string.
    */
   public static String getUserAgent() {
-    return String.format("influxdb3-java:%s", getVersion());
+    return String.format("influxdb3-java/%s", getVersion());
   }
 }

--- a/src/main/java/com/influxdb/v3/client/internal/Identity.java
+++ b/src/main/java/com/influxdb/v3/client/internal/Identity.java
@@ -1,3 +1,24 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.influxdb.v3.client.internal;
 
 /**

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -79,9 +79,7 @@ final class RestClient implements AutoCloseable {
         this.config = config;
 
         // user agent version
-        Package mainPackage = RestClient.class.getPackage();
-        String version = mainPackage != null ? mainPackage.getImplementationVersion() : "unknown";
-        this.userAgent = String.format("influxdb3-java/%s", version != null ? version : "unknown");
+        this.userAgent = Identity.getUserAgent();
 
         // URL
         String host = config.getHost();

--- a/src/test/java/com/influxdb/v3/client/internal/FlightSqlClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/FlightSqlClientTest.java
@@ -115,9 +115,11 @@ public class FlightSqlClientTest {
 
             Assertions.assertThat(incomingHeaders.keys()).containsOnly(
                     "authorization",
+                    "user-agent",
                     GrpcUtil.MESSAGE_ACCEPT_ENCODING
             );
             Assertions.assertThat(incomingHeaders.get("authorization")).isEqualTo("Bearer my-token");
+            Assertions.assertThat(incomingHeaders.get("user-agent")).isEqualTo(Identity.getUserAgent());
         }
     }
 
@@ -133,7 +135,10 @@ public class FlightSqlClientTest {
 
             final CallHeaders incomingHeaders = callHeadersMiddleware.headers;
 
-            Assertions.assertThat(incomingHeaders.keys()).containsOnly(GrpcUtil.MESSAGE_ACCEPT_ENCODING);
+            Assertions.assertThat(incomingHeaders.keys()).containsOnly(
+              "user-agent",
+              GrpcUtil.MESSAGE_ACCEPT_ENCODING
+            );
             Assertions.assertThat(incomingHeaders.get("authorization")).isNull();
         }
     }
@@ -151,7 +156,10 @@ public class FlightSqlClientTest {
 
             final CallHeaders incomingHeaders = callHeadersMiddleware.headers;
 
-            Assertions.assertThat(incomingHeaders.keys()).containsOnly(GrpcUtil.MESSAGE_ACCEPT_ENCODING);
+            Assertions.assertThat(incomingHeaders.keys()).containsOnly(
+              "user-agent",
+              GrpcUtil.MESSAGE_ACCEPT_ENCODING
+            );
             Assertions.assertThat(incomingHeaders.get("authorization")).isNull();
         }
     }
@@ -172,6 +180,7 @@ public class FlightSqlClientTest {
 
             Assertions.assertThat(incomingHeaders.keys()).containsOnly(
                     "authorization",
+                    "user-agent",
                     "x-tracing-id",
                     GrpcUtil.MESSAGE_ACCEPT_ENCODING
             );
@@ -200,6 +209,7 @@ public class FlightSqlClientTest {
 
             Assertions.assertThat(incomingHeaders.keys()).containsOnly(
                     "authorization",
+                    "user-agent",
                     "x-tracing-id",
                     "x-invoice-id",
                     GrpcUtil.MESSAGE_ACCEPT_ENCODING
@@ -229,6 +239,7 @@ public class FlightSqlClientTest {
 
             Assertions.assertThat(incomingHeaders.keys()).containsOnly(
                     "authorization",
+                    "user-agent",
                     "x-tracing-id",
                     GrpcUtil.MESSAGE_ACCEPT_ENCODING
             );
@@ -254,6 +265,7 @@ public class FlightSqlClientTest {
             Assertions.assertThat(incomingHeaders.keys()).containsOnly(
                     "authorization",
                     "x-tracing-id",
+                    "user-agent",
                     GrpcUtil.MESSAGE_ACCEPT_ENCODING
             );
             Assertions.assertThat(incomingHeaders.get("X-Tracing-Id")).isEqualTo("987");

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -139,7 +139,7 @@ public class RestClientTest extends AbstractMockServerTest {
         RecordedRequest recordedRequest = mockServer.takeRequest();
 
         String userAgent = recordedRequest.getHeader("User-Agent");
-        Assertions.assertThat(userAgent).startsWith("influxdb3-java:");
+        Assertions.assertThat(userAgent).startsWith("influxdb3-java/");
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -139,7 +139,7 @@ public class RestClientTest extends AbstractMockServerTest {
         RecordedRequest recordedRequest = mockServer.takeRequest();
 
         String userAgent = recordedRequest.getHeader("User-Agent");
-        Assertions.assertThat(userAgent).startsWith("influxdb3-java/");
+        Assertions.assertThat(userAgent).startsWith("influxdb3-java:");
     }
 
     @Test


### PR DESCRIPTION
Closes #

## Proposed Changes

* Add an Identity class for collecting information related to the identity of the client
* Update `user-agent` of rest client to form `influxdb3-java:<release>` 
* Add a default `user-agent` metadata entry for FlightSQLClient

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
