### PR TITLE
fix: handle OSS/Edge error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.9.0 [unreleased]
 
+### Bug Fixes
+
+1. [#148](https://github.com/InfluxCommunity/influxdb3-java/pull/148): InfluxDB Edge (OSS) error handling
+
 ## 0.8.0 [2024-06-24]
 
 ### Features

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -176,7 +176,12 @@ final class RestClient implements AutoCloseable {
             String body = response.body();
             if (!body.isEmpty()) {
                 try {
-                    reason = objectMapper.readTree(body).get("message").asText();
+                    final var obj = objectMapper.readTree(body);
+                    if (obj.hasNonNull("message")) { // Cloud
+                        reason = obj.get("message").asText();
+                    } else if (obj.hasNonNull("error_message")) { // OSS (Edge)
+                        reason = obj.get("error_message").asText();
+                    }
                 } catch (JsonProcessingException e) {
                     LOG.debug("Can't parse msg from response {}", response);
                 }

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -26,7 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.SecureRandom;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -179,7 +179,7 @@ final class RestClient implements AutoCloseable {
             if (!body.isEmpty()) {
                 try {
                     final JsonNode root = objectMapper.readTree(body);
-                    for (String field : Arrays.asList("message", "error_message", "error")) {
+                    for (String field : List.of("message", "error_message", "error")) {
                         final JsonNode node = root.findValue(field);
                         if (node != null) {
                             reason = node.asText();

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -26,6 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -35,6 +36,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -176,11 +178,13 @@ final class RestClient implements AutoCloseable {
             String body = response.body();
             if (!body.isEmpty()) {
                 try {
-                    final var obj = objectMapper.readTree(body);
-                    if (obj.hasNonNull("message")) { // Cloud
-                        reason = obj.get("message").asText();
-                    } else if (obj.hasNonNull("error_message")) { // OSS (Edge)
-                        reason = obj.get("error_message").asText();
+                    final JsonNode root = objectMapper.readTree(body);
+                    for (String field : Arrays.asList("message", "error_message", "error")) {
+                        final JsonNode node = root.findValue(field);
+                        if (node != null) {
+                            reason = node.asText();
+                            break;
+                        }
                     }
                 } catch (JsonProcessingException e) {
                     LOG.debug("Can't parse msg from response {}", response);

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -179,7 +179,8 @@ final class RestClient implements AutoCloseable {
             if (!body.isEmpty()) {
                 try {
                     final JsonNode root = objectMapper.readTree(body);
-                    for (String field : List.of("message", "error_message", "error")) {
+                    final List<String> possibilities = List.of("message", "error_message", "error");
+                    for (final String field : possibilities) {
                         final JsonNode node = root.findValue(field);
                         if (node != null) {
                             reason = node.asText();

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -359,7 +359,7 @@ public class RestClientTest extends AbstractMockServerTest {
     @Test
     public void errorFromBodyEdgeWithMessage() { // OSS/Edge specific error message
         mockServer.enqueue(createResponse(400)
-                .setBody("{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"invalid field value in line protocol\"}}"));
+                .setBody("{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"invalid field value\"}}"));
 
         restClient = new RestClient(new ClientConfig.Builder()
                 .host(baseURL)
@@ -368,7 +368,7 @@ public class RestClientTest extends AbstractMockServerTest {
         Assertions.assertThatThrownBy(
                         () -> restClient.request("ping", HttpMethod.GET, null, null, null))
                 .isInstanceOf(InfluxDBApiException.class)
-                .hasMessage("HTTP status code: 400; Message: invalid field value in line protocol");
+                .hasMessage("HTTP status code: 400; Message: invalid field value");
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -342,6 +342,36 @@ public class RestClientTest extends AbstractMockServerTest {
     }
 
     @Test
+    public void errorFromBodyEdgeWithoutMessage() { // OSS/Edge error message
+        mockServer.enqueue(createResponse(400)
+                .setBody("{\"error\":\"parsing failed\"}"));
+
+        restClient = new RestClient(new ClientConfig.Builder()
+                .host(baseURL)
+                .build());
+
+        Assertions.assertThatThrownBy(
+                        () -> restClient.request("ping", HttpMethod.GET, null, null, null))
+                .isInstanceOf(InfluxDBApiException.class)
+                .hasMessage("HTTP status code: 400; Message: parsing failed");
+    }
+
+    @Test
+    public void errorFromBodyEdgeWithMessage() { // OSS/Edge specific error message
+        mockServer.enqueue(createResponse(400)
+                .setBody("{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"invalid field value in line protocol\"}}"));
+
+        restClient = new RestClient(new ClientConfig.Builder()
+                .host(baseURL)
+                .build());
+
+        Assertions.assertThatThrownBy(
+                        () -> restClient.request("ping", HttpMethod.GET, null, null, null))
+                .isInstanceOf(InfluxDBApiException.class)
+                .hasMessage("HTTP status code: 400; Message: invalid field value in line protocol");
+    }
+
+    @Test
     public void errorFromBodyText() {
         mockServer.enqueue(createResponse(402)
                 .setBody("token is over the limit"));

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -45,6 +45,21 @@ class WriteOptionsTest {
 
 
     @Test
+    void optionsSelf() {
+        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
+
+        Assertions.assertThat(options).isEqualTo(options);
+    }
+
+    @Test
+    void optionsAlien() {
+        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
+
+        Assertions.assertThat(options).isNotEqualTo(null);
+        Assertions.assertThat(options).isNotEqualTo(this);
+    }
+
+    @Test
     void optionsEqualAll() {
         WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
         WriteOptions optionsViaBuilder = new WriteOptions.Builder()

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -45,16 +45,10 @@ class WriteOptionsTest {
 
 
     @Test
-    void optionsSelf() {
+    void optionsBasics() {
         WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
 
         Assertions.assertThat(options).isEqualTo(options);
-    }
-
-    @Test
-    void optionsAlien() {
-        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
-
         Assertions.assertThat(options).isNotEqualTo(null);
         Assertions.assertThat(options).isNotEqualTo(this);
     }


### PR DESCRIPTION
Closes #147 

## Proposed Changes

OSS (Edge) returns slightly different JSON payload on error. A small change in handling it makes the client throw expected `InfluxDBException` instead of NPE.

Tested with OSS [aa28302](https://github.com/influxdata/influxdb/commit/aa28302cddc7943dfe162f0cfe350ad3609f95e6) and Cloud as of today.

_Note: no idea why one of the patch lines is only partially covered by test, and the check fails._

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
