### PR TITLE
fix: parsing timestamp with specified precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#148](https://github.com/InfluxCommunity/influxdb3-java/pull/148): InfluxDB Edge (OSS) error handling
+1. [#153](https://github.com/InfluxCommunity/influxdb3-java/pull/153): Parsing timestamp columns
 
 ## 0.8.0 [2024-06-24]
 

--- a/src/main/java/com/influxdb/v3/client/Point.java
+++ b/src/main/java/com/influxdb/v3/client/Point.java
@@ -133,7 +133,7 @@ public final class Point {
   }
 
   /**
-   * Get timestamp. Can be null if not set.
+   * Get timestamp in nanoseconds. If the timestamp is not set, returns null.
    *
    * @return timestamp or null
    */

--- a/src/main/java/com/influxdb/v3/client/PointValues.java
+++ b/src/main/java/com/influxdb/v3/client/PointValues.java
@@ -96,7 +96,7 @@ public final class PointValues {
   }
 
   /**
-   * Get timestamp. Can be null if not set.
+   * Get timestamp in nanoseconds. If the timestamp is not set, returns null.
    *
    * @return timestamp or null
    */

--- a/src/main/java/com/influxdb/v3/client/internal/VectorSchemaRootConverter.java
+++ b/src/main/java/com/influxdb/v3/client/internal/VectorSchemaRootConverter.java
@@ -105,7 +105,9 @@ final class VectorSchemaRootConverter {
         return p;
     }
 
-    private void setTimestamp(@Nonnull final Object value, @Nonnull final Field schema, @Nonnull final PointValues pointValues) {
+    private void setTimestamp(@Nonnull final Object value,
+                              @Nonnull final Field schema,
+                              @Nonnull final PointValues pointValues) {
         if (value instanceof Long) {
             if (schema.getFieldType().getType() instanceof ArrowType.Timestamp) {
                 ArrowType.Timestamp type = (ArrowType.Timestamp) schema.getFieldType().getType();
@@ -125,7 +127,8 @@ final class VectorSchemaRootConverter {
                         timeUnit = TimeUnit.NANOSECONDS;
                         break;
                 }
-                pointValues.setTimestamp(Instant.ofEpochSecond(0, TimeUnit.NANOSECONDS.convert((Long) value, timeUnit)));
+                long nanoseconds = TimeUnit.NANOSECONDS.convert((Long) value, timeUnit);
+                pointValues.setTimestamp(Instant.ofEpochSecond(0, nanoseconds));
             } else {
                 pointValues.setTimestamp(Instant.ofEpochMilli((Long) value));
             }

--- a/src/main/java/com/influxdb/v3/client/internal/VectorSchemaRootConverter.java
+++ b/src/main/java/com/influxdb/v3/client/internal/VectorSchemaRootConverter.java
@@ -26,11 +26,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.util.Text;
 
 import com.influxdb.v3.client.PointValues;
@@ -79,7 +82,7 @@ final class VectorSchemaRootConverter {
 
             if (metaType == null) {
                 if (Objects.equals(name, "time") && (value instanceof Long || value instanceof LocalDateTime)) {
-                    setTimestamp(value, p);
+                    setTimestamp(value, schema, p);
                 } else {
                     // just push as field If you don't know what type is it
                     p.setField(name, value);
@@ -96,15 +99,36 @@ final class VectorSchemaRootConverter {
             } else if ("tag".equals(valueType) && value instanceof String) {
                 p.setTag(name, (String) value);
             } else if ("timestamp".equals(valueType)) {
-                setTimestamp(value, p);
+                setTimestamp(value, schema, p);
             }
         }
         return p;
     }
 
-    private void setTimestamp(@Nonnull final Object value, @Nonnull final PointValues pointValues) {
+    private void setTimestamp(@Nonnull final Object value, @Nonnull final Field schema, @Nonnull final PointValues pointValues) {
         if (value instanceof Long) {
-            pointValues.setTimestamp(Instant.ofEpochMilli((Long) value));
+            if (schema.getFieldType().getType() instanceof ArrowType.Timestamp) {
+                ArrowType.Timestamp type = (ArrowType.Timestamp) schema.getFieldType().getType();
+                TimeUnit timeUnit;
+                switch (type.getUnit()) {
+                    case SECOND:
+                        timeUnit = TimeUnit.SECONDS;
+                        break;
+                    case MILLISECOND:
+                        timeUnit = TimeUnit.MILLISECONDS;
+                        break;
+                    case MICROSECOND:
+                        timeUnit = TimeUnit.MICROSECONDS;
+                        break;
+                    default:
+                    case NANOSECOND:
+                        timeUnit = TimeUnit.NANOSECONDS;
+                        break;
+                }
+                pointValues.setTimestamp(Instant.ofEpochSecond(0, TimeUnit.NANOSECONDS.convert((Long) value, timeUnit)));
+            } else {
+                pointValues.setTimestamp(Instant.ofEpochMilli((Long) value));
+            }
         } else if (value instanceof LocalDateTime) {
             pointValues.setTimestamp(((LocalDateTime) value).toInstant(ZoneOffset.UTC));
         }

--- a/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
@@ -189,7 +189,7 @@ class VectorSchemaRootConverterTest {
             ((TimeMilliVector) timeVector).setSafe(0, timeValue);
         } else if (timeVector instanceof TimeStampVector) {
             ((TimeStampVector) timeVector).setSafe(0, timeValue);
-        }else if (timeVector instanceof BigIntVector) {
+        } else if (timeVector instanceof BigIntVector) {
             ((BigIntVector) timeVector).setSafe(0, timeValue);
         } else {
             throw new RuntimeException("Unexpected vector type: " + timeVector.getClass().getName());

--- a/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.TimeMilliVector;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -59,8 +60,52 @@ class VectorSchemaRootConverterTest {
     }
 
     @Test
-    void timestampAsArrowTimestamp() {
+    void timestampAsArrowTimestampSecond() {
+        try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Timestamp(TimeUnit.SECOND, "UTC"))) {
+
+            PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
+
+            BigInteger expected = BigInteger.valueOf(45_678L * 1_000_000_000);
+            Assertions.assertThat((BigInteger) pointValues.getTimestamp()).isEqualByComparingTo(expected);
+        }
+    }
+
+    @Test
+    void timestampAsArrowTimestampMillisecond() {
         try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"))) {
+
+            PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
+
+            BigInteger expected = BigInteger.valueOf(45_678L * 1_000_000);
+            Assertions.assertThat((BigInteger) pointValues.getTimestamp()).isEqualByComparingTo(expected);
+        }
+    }
+
+    @Test
+    void timestampAsArrowTimestampMicrosecond() {
+        try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"))) {
+
+            PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
+
+            BigInteger expected = BigInteger.valueOf(45_678L * 1_000);
+            Assertions.assertThat((BigInteger) pointValues.getTimestamp()).isEqualByComparingTo(expected);
+        }
+    }
+
+    @Test
+    void timestampAsArrowTimestampNanosecond() {
+        try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC"))) {
+
+            PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
+
+            BigInteger expected = BigInteger.valueOf(45_678L);
+            Assertions.assertThat((BigInteger) pointValues.getTimestamp()).isEqualByComparingTo(expected);
+        }
+    }
+
+    @Test
+    void timestampAsArrowInt() {
+        try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Int(64, true))) {
 
             PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
 
@@ -144,6 +189,8 @@ class VectorSchemaRootConverterTest {
             ((TimeMilliVector) timeVector).setSafe(0, timeValue);
         } else if (timeVector instanceof TimeStampVector) {
             ((TimeStampVector) timeVector).setSafe(0, timeValue);
+        }else if (timeVector instanceof BigIntVector) {
+            ((BigIntVector) timeVector).setSafe(0, timeValue);
         } else {
             throw new RuntimeException("Unexpected vector type: " + timeVector.getClass().getName());
         }

--- a/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/VectorSchemaRootConverterTest.java
@@ -104,6 +104,17 @@ class VectorSchemaRootConverterTest {
     }
 
     @Test
+    void timestampAsArrowTimestampNanosecondWithoutTimezone() {
+        try (VectorSchemaRoot root = createTimeVector(45_978, new ArrowType.Timestamp(TimeUnit.NANOSECOND, null))) {
+
+            PointValues pointValues = VectorSchemaRootConverter.INSTANCE.toPointValues(0, root, root.getFieldVectors());
+
+            BigInteger expected = BigInteger.valueOf(45_978L);
+            Assertions.assertThat((BigInteger) pointValues.getTimestamp()).isEqualByComparingTo(expected);
+        }
+    }
+
+    @Test
     void timestampAsArrowInt() {
         try (VectorSchemaRoot root = createTimeVector(45_678, new ArrowType.Int(64, true))) {
 


### PR DESCRIPTION
Closes #154

## Proposed Changes

This PR modifies how the client parses timestamps. Recently, InfluxDB 3 began returning timestamps in nanoseconds, necessitating a change in the parsing method. The parsing is now more robust.

![image](https://github.com/InfluxCommunity/influxdb3-java/assets/455137/1ac2da81-f0eb-45da-aa83-b8fefe6b0c6b)


https://app.circleci.com/pipelines/github/InfluxCommunity/influxdb3-java/510/workflows/51f380f3-1cd0-49bd-bb11-fe2f72cb34dc/jobs/3031?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
