### PR TITLE
fix: add Edge authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#148](https://github.com/InfluxCommunity/influxdb3-java/pull/148): InfluxDB Edge (OSS) error handling
 1. [#153](https://github.com/InfluxCommunity/influxdb3-java/pull/153): Parsing timestamp columns
+1. [#158](https://github.com/InfluxCommunity/influxdb3-java/pull/158): Add InfluxDB Edge (OSS) authentication support.
 
 ## 0.8.0 [2024-06-24]
 

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -444,6 +444,7 @@ public interface InfluxDBClient extends AutoCloseable {
      * <ul>
      *   <li>INFLUX_HOST - cloud/server URL <i>required</i></li>
      *   <li>INFLUX_TOKEN - authentication token <i>required</i></li>
+     *   <li>INFLUX_AUTH_SCHEME - authentication scheme</li>
      *   <li>INFLUX_ORG - organization name</li>
      *   <li>INFLUX_DATABASE - database (bucket) name</li>
      *   <li>INFLUX_PRECISION - timestamp precision when writing data</li>
@@ -453,6 +454,7 @@ public interface InfluxDBClient extends AutoCloseable {
      * <ul>
      *   <li>influx.host - cloud/server URL <i>required</i></li>
      *   <li>influx.token - authentication token <i>required</i></li>
+     *   <li>influx.authScheme - authentication scheme</li>
      *   <li>influx.org - organization name</li>
      *   <li>influx.database - database (bucket) name</li>
      *   <li>influx.precision - timestamp precision when writing data</li>

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -46,6 +46,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  * <ul>
  *     <li><code>host</code> - hostname or IP address of the InfluxDB server</li>
  *     <li><code>token</code> - authentication token for accessing the InfluxDB server</li>
+ *     <li><code>authScheme</code> - authentication scheme</li>
  *     <li><code>organization</code> - organization to be used for operations</li>
  *     <li><code>database</code> - database to be used for InfluxDB operations</li>
  *     <li><code>writePrecision</code> - precision to use when writing points to InfluxDB</li>
@@ -86,6 +87,7 @@ public final class ClientConfig {
 
     private final String host;
     private final char[] token;
+    private final String authScheme;
     private final String organization;
     private final String database;
     private final WritePrecision writePrecision;
@@ -116,6 +118,16 @@ public final class ClientConfig {
     @Nullable
     public char[] getToken() {
         return token;
+    }
+
+    /**
+     * Gets authentication scheme.
+     *
+     * @return authentication scheme, may be null
+     */
+    @Nullable
+    public String getAuthScheme() {
+        return authScheme;
     }
 
     /**
@@ -247,6 +259,7 @@ public final class ClientConfig {
         ClientConfig that = (ClientConfig) o;
         return Objects.equals(host, that.host)
                 && Arrays.equals(token, that.token)
+                && Objects.equals(authScheme, that.authScheme)
                 && Objects.equals(organization, that.organization)
                 && Objects.equals(database, that.database)
                 && writePrecision == that.writePrecision
@@ -262,7 +275,7 @@ public final class ClientConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, Arrays.hashCode(token), organization,
+        return Objects.hash(host, Arrays.hashCode(token), authScheme, organization,
           database, writePrecision, gzipThreshold,
           timeout, allowHttpRedirects, disableServerCertificateValidation,
           proxy, authenticator, headers,
@@ -295,6 +308,7 @@ public final class ClientConfig {
     public static final class Builder {
         private String host;
         private char[] token;
+        private String authScheme;
         private String organization;
         private String database;
         private WritePrecision writePrecision;
@@ -330,6 +344,20 @@ public final class ClientConfig {
         public Builder token(@Nullable final char[] token) {
 
             this.token = token;
+            return this;
+        }
+
+        /**
+         * Sets authentication scheme.
+         *
+         * @param authScheme authentication scheme.
+         *                   Default <code>null</code> for Cloud access, set to 'Bearer' for Edge.
+         * @return this
+         */
+        @Nonnull
+        public Builder authScheme(@Nullable final String authScheme) {
+
+            this.authScheme = authScheme;
             return this;
         }
 
@@ -525,6 +553,9 @@ public final class ClientConfig {
             if (parameters.containsKey("token")) {
                 this.token(parameters.get("token").toCharArray());
             }
+            if (parameters.containsKey("authScheme")) {
+                this.authScheme(parameters.get("authScheme"));
+            }
             if (parameters.containsKey("org")) {
                 this.organization(parameters.get("org"));
             }
@@ -564,6 +595,10 @@ public final class ClientConfig {
             final String token = get.apply("INFLUX_TOKEN", "influx.token");
             if (token != null) {
                 this.token(token.toCharArray());
+            }
+            final String authScheme = get.apply("INFLUX_AUTH_SCHEME", "influx.authScheme");
+            if (authScheme != null) {
+                this.authScheme(authScheme);
             }
             final String org = get.apply("INFLUX_ORG", "influx.org");
             if (org != null) {
@@ -612,6 +647,7 @@ public final class ClientConfig {
     private ClientConfig(@Nonnull final Builder builder) {
         host = builder.host;
         token = builder.token;
+        authScheme = builder.authScheme;
         organization = builder.organization;
         database = builder.database;
         writePrecision = builder.writePrecision != null ? builder.writePrecision : WritePrecision.NS;

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -162,7 +162,11 @@ final class RestClient implements AutoCloseable {
         }
         request.header("User-Agent", userAgent);
         if (config.getToken() != null && config.getToken().length > 0) {
-            request.header("Authorization", String.format("Token %s", new String(config.getToken())));
+            String authScheme = config.getAuthScheme();
+            if (authScheme == null) {
+                authScheme = "Token";
+            }
+            request.header("Authorization", String.format("%s %s", authScheme, new String(config.getToken())));
         }
 
         HttpResponse<String> response;

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -117,6 +117,13 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getDatabase()).isEqualTo(null);
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.S);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
+
+        cfg = new ClientConfig.Builder()
+                .build("http://localhost:9999/"
+                        + "?token=my-token&authScheme=my-auth");
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getAuthScheme()).isEqualTo("my-auth");
     }
 
     @Test
@@ -136,7 +143,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
 
-        // simple
+        // basic
         env = Map.of(
                 "INFLUX_HOST", "http://localhost:9999/",
                 "INFLUX_TOKEN", "my-token",
@@ -152,6 +159,18 @@ class ClientConfigTest {
         // these are defaults
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // with Edge authentication
+        env = Map.of(
+                "INFLUX_HOST", "http://localhost:9999/",
+                "INFLUX_TOKEN", "my-token",
+                "INFLUX_AUTH_SCHEME", "my-auth"
+        );
+        cfg = new ClientConfig.Builder()
+                .build(env, null);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getAuthScheme()).isEqualTo("my-auth");
 
         // with write options
         env = Map.of(
@@ -188,7 +207,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
 
-        // simple
+        // basic
         properties = new Properties();
         properties.put("influx.host", "http://localhost:9999/");
         properties.put("influx.token", "my-token");
@@ -203,6 +222,17 @@ class ClientConfigTest {
         // these are defaults
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
+
+        // with custom auth scheme
+        properties = new Properties();
+        properties.put("influx.host", "http://localhost:9999/");
+        properties.put("influx.token", "my-token");
+        properties.put("influx.authScheme", "my-auth");
+        cfg = new ClientConfig.Builder()
+                .build(new HashMap<>(), properties);
+        Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
+        Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
+        Assertions.assertThat(cfg.getAuthScheme()).isEqualTo("my-auth");
 
         // with write options
         properties = new Properties();

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -111,6 +111,24 @@ public class RestClientTest extends AbstractMockServerTest {
     }
 
     @Test
+    public void authenticationHeaderCustomAuthScheme() throws InterruptedException {
+        mockServer.enqueue(createResponse(200));
+
+        restClient = new RestClient(new ClientConfig.Builder()
+                .host(baseURL)
+                .token("my-token".toCharArray())
+                .authScheme("my-auth-scheme")
+                .build());
+
+        restClient.request("ping", HttpMethod.GET, null, null, null);
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+
+        String authorization = recordedRequest.getHeader("Authorization");
+        Assertions.assertThat(authorization).isEqualTo("my-auth-scheme my-token");
+    }
+
+    @Test
     public void authenticationHeaderNotDefined() throws InterruptedException {
         mockServer.enqueue(createResponse(200));
 


### PR DESCRIPTION
## Proposed Changes

Adds `authScheme` config property | `INFLUX_AUTH_SCHEME` env var | `influx.authScheme` java property to be used to specify non-default authentication scheme. For Cloud access does not need to be set, for Edge/OSS it should be set to `Bearer`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
