### PR TITLE
feat: set max rpc message size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#229](https://github.com/InfluxCommunity/influxdb3-java/pull/229): Support proxy and custom ssl root certificates
+2. [#231](https://github.com/InfluxCommunity/influxdb3-java/pull/231): Allow set rpc max message size through maxInboundMessageSize in ClientConfig
 
 ## 1.0.0 [2024-12-11]
 

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -57,10 +57,11 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>disableServerCertificateValidation</code> -
  *          disable server certificate validation for HTTPS connections
  *     </li>
- *     <li><code>proxyUrl</code> - Proxy url for query api and write api</li>
+ *     <li><code>proxyUrl</code> - proxy url for query api and write api</li>
  *     <li><code>authenticator</code> - HTTP proxy authenticator</li>
  *     <li><code>headers</code> - headers to be added to requests</li>
- *     <li><code>sslRootsFilePath</code> - Path to the stored certificates file in PEM format</li>
+ *     <li><code>sslRootsFilePath</code> - path to the stored certificates file in PEM format</li>
+ *     <li><code>maxInboundMessageSize</code> - rpc max message size client can receive</li>
  * </ul>
  * <p>
  * If you want to create a client with custom configuration, you can use following code:
@@ -102,6 +103,7 @@ public final class ClientConfig {
     private final Authenticator authenticator;
     private final Map<String, String> headers;
     private final String sslRootsFilePath;
+    private final Integer maxInboundMessageSize;
 
     /**
      * Deprecated use {@link #proxyUrl}.
@@ -241,6 +243,16 @@ public final class ClientConfig {
     }
 
     /**
+     * Gets rpc max message size client can receive.
+     *
+     * @return the size in Integer, may be null
+     */
+    @Nullable
+    public Integer getMaxInboundMessageSize() {
+        return maxInboundMessageSize;
+    }
+
+    /**
      * Gets certificates file path.
      *
      * @return the certificates file path, may be null
@@ -303,7 +315,8 @@ public final class ClientConfig {
                 && Objects.equals(proxyUrl, that.proxyUrl)
                 && Objects.equals(authenticator, that.authenticator)
                 && Objects.equals(headers, that.headers)
-                && Objects.equals(sslRootsFilePath, that.sslRootsFilePath);
+                && Objects.equals(sslRootsFilePath, that.sslRootsFilePath)
+                && Objects.equals(maxInboundMessageSize, that.maxInboundMessageSize);
     }
 
     @Override
@@ -312,7 +325,7 @@ public final class ClientConfig {
                 database, writePrecision, gzipThreshold,
                 timeout, allowHttpRedirects, disableServerCertificateValidation,
                 proxy, proxyUrl, authenticator, headers,
-                defaultTags, sslRootsFilePath);
+                defaultTags, sslRootsFilePath, maxInboundMessageSize);
     }
 
     @Override
@@ -332,6 +345,7 @@ public final class ClientConfig {
                 .add("headers=" + headers)
                 .add("defaultTags=" + defaultTags)
                 .add("sslRootsFilePath=" + sslRootsFilePath)
+                .add("maxInboundMessageSize=" + maxInboundMessageSize)
                 .toString();
     }
 
@@ -357,6 +371,7 @@ public final class ClientConfig {
         private Authenticator authenticator;
         private Map<String, String> headers;
         private String sslRootsFilePath;
+        private Integer maxInboundMessageSize;
 
         /**
          * Sets the URL of the InfluxDB server.
@@ -590,6 +605,19 @@ public final class ClientConfig {
         }
 
         /**
+         * Set rpc max message size client can receive. Default is 'null'.
+         *
+         * @param maxInboundMessageSize The size in Integer
+         * @return this
+         */
+        @Nonnull
+        public Builder maxInboundMessageSize(@Nullable final Integer maxInboundMessageSize) {
+
+            this.maxInboundMessageSize = maxInboundMessageSize;
+            return this;
+        }
+
+        /**
          * Build an instance of {@code ClientConfig}.
          *
          * @return the configuration for an {@code InfluxDBClient}.
@@ -728,5 +756,6 @@ public final class ClientConfig {
         authenticator = builder.authenticator;
         headers = builder.headers;
         sslRootsFilePath = builder.sslRootsFilePath;
+        maxInboundMessageSize = builder.maxInboundMessageSize;
     }
 }

--- a/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
@@ -141,11 +141,10 @@ final class FlightSqlClient implements AutoCloseable {
 
     @Nonnull
     private FlightClient createFlightClient(@Nonnull final ClientConfig config) {
-        Location location = createLocation(config);
+        URI uri = createLocation(config).getUri();
+        final NettyChannelBuilder nettyChannelBuilder = NettyChannelBuilder.forAddress(uri.getHost(), uri.getPort());
 
-        final NettyChannelBuilder nettyChannelBuilder = NettyChannelBuilder.forTarget(location.getUri().getHost());
-
-        if (LocationSchemes.GRPC_TLS.equals(location.getUri().getScheme())) {
+        if (LocationSchemes.GRPC_TLS.equals(uri.getScheme())) {
             nettyChannelBuilder.useTransportSecurity();
 
             SslContext nettySslContext = createNettySslContext(config);
@@ -164,8 +163,10 @@ final class FlightSqlClient implements AutoCloseable {
         }
 
         nettyChannelBuilder.maxTraceEvents(0)
-                .maxInboundMessageSize(Integer.MAX_VALUE)
-                .maxInboundMetadataSize(Integer.MAX_VALUE);
+                .maxInboundMetadataSize(Integer.MAX_VALUE)
+                .maxInboundMessageSize(config.getMaxInboundMessageSize() != null ?
+                        config.getMaxInboundMessageSize() : Integer.MAX_VALUE
+                );
 
         return FlightGrpcUtils.createFlightClient(new RootAllocator(Long.MAX_VALUE), nettyChannelBuilder.build());
     }

--- a/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
@@ -164,7 +164,8 @@ final class FlightSqlClient implements AutoCloseable {
 
         nettyChannelBuilder.maxTraceEvents(0)
                 .maxInboundMetadataSize(Integer.MAX_VALUE)
-                .maxInboundMessageSize(config.getMaxInboundMessageSize() != null ?
+                .maxInboundMessageSize(config.getMaxInboundMessageSize() != null
+                        ?
                         config.getMaxInboundMessageSize() : Integer.MAX_VALUE
                 );
 

--- a/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/FlightSqlClient.java
@@ -162,12 +162,11 @@ final class FlightSqlClient implements AutoCloseable {
             LOG.warn("proxy property in ClientConfig will not work in query api, use proxyUrl property instead");
         }
 
+        int maxInboundMessageSize = config.getMaxInboundMessageSize() != null ?
+                config.getMaxInboundMessageSize() : Integer.MAX_VALUE;
         nettyChannelBuilder.maxTraceEvents(0)
                 .maxInboundMetadataSize(Integer.MAX_VALUE)
-                .maxInboundMessageSize(config.getMaxInboundMessageSize() != null
-                        ?
-                        config.getMaxInboundMessageSize() : Integer.MAX_VALUE
-                );
+                .maxInboundMessageSize(maxInboundMessageSize);
 
         return FlightGrpcUtils.createFlightClient(new RootAllocator(Long.MAX_VALUE), nettyChannelBuilder.build());
     }

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -289,7 +289,7 @@ class ClientConfigTest {
             ClientConfig.Builder builder = new ClientConfig.Builder()
                     .host(host)
                     .database("test")
-                    .maxInboundMessageSize(200); // Set very low message size for testing
+                    .maxInboundMessageSize(200); // Set very small message size for testing
             String query = "Select * from \"nothing\"";
             try (InfluxDBClient influxDBClient = InfluxDBClient.getInstance(builder.build())) {
                 try (Stream<PointValues> points = influxDBClient.queryPoints(query)) {

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -293,7 +293,9 @@ class ClientConfigTest {
             String query = "Select * from \"nothing\"";
             try (InfluxDBClient influxDBClient = InfluxDBClient.getInstance(builder.build())) {
                 try (Stream<PointValues> points = influxDBClient.queryPoints(query)) {
-                    FlightRuntimeException exception = Assertions.catchThrowableOfType(FlightRuntimeException.class, points::count);
+                    FlightRuntimeException exception = Assertions.catchThrowableOfType(
+                            FlightRuntimeException.class,
+                            points::count);
                     Assertions.assertThat(exception.status().code()).isEqualTo(CallStatus.RESOURCE_EXHAUSTED.code());
                 }
             }

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -320,7 +320,9 @@ class ClientConfigTest {
     private NoOpFlightProducer simpleProducer(@Nonnull final VectorSchemaRoot vectorSchemaRoot) {
         return new NoOpFlightProducer() {
             @Override
-            public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
+            public void getStream(final CallContext context,
+                                  final Ticket ticket,
+                                  final ServerStreamListener listener) {
                 listener.start(vectorSchemaRoot);
                 if (listener.isReady()) {
                     listener.putNext();

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -284,12 +284,12 @@ class ClientConfigTest {
         ) {
             flightServer.start();
 
-            // Set small message size case
+            // Set very small message size for testing
             String host = String.format("http://%s:%d", uri.getHost(), uri.getPort());
             ClientConfig.Builder builder = new ClientConfig.Builder()
                     .host(host)
                     .database("test")
-                    .maxInboundMessageSize(200); // Set very small message size for testing
+                    .maxInboundMessageSize(200);
             String query = "Select * from \"nothing\"";
             try (InfluxDBClient influxDBClient = InfluxDBClient.getInstance(builder.build())) {
                 try (Stream<PointValues> points = influxDBClient.queryPoints(query)) {


### PR DESCRIPTION
Closes #

## Proposed Changes

_ Set the maximum number of message size client can receive.
_ I have to change NettyChannelBuilder.forTarget back to NettyChannelBuilder.forAddress because the latter works well with ip addresses (more flexible).
_ I set maxInboundMessageSize = Integer.MAX_VALUE when the user inputs maxInboundMessageSize = null just for backward compatibility reasons.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
