### PR TITLE
feat: fast no-sync write support

### DIFF
--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -445,6 +445,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>database - database (bucket) name</li>
      *   <li>precision - timestamp precision when writing data</li>
      *   <li>gzipThreshold - payload size size for gzipping data</li>
+     *   <li>writeNoSync - skip waiting for WAL persistence on write</li>
      * </ul>
      *
      * @param connectionString connection string
@@ -477,6 +478,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>INFLUX_DATABASE - database (bucket) name</li>
      *   <li>INFLUX_PRECISION - timestamp precision when writing data</li>
      *   <li>INFLUX_GZIP_THRESHOLD - payload size size for gzipping data</li>
+     *   <li>INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write</li>
      * </ul>
      * Supported system properties:
      * <ul>
@@ -487,6 +489,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.database - database (bucket) name</li>
      *   <li>influx.precision - timestamp precision when writing data</li>
      *   <li>influx.gzipThreshold - payload size size for gzipping data</li>
+     *   <li>influx.writeNoSync - skip waiting for WAL persistence on write</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -62,13 +62,18 @@ public final class WriteOptions {
      */
     public static final Integer DEFAULT_GZIP_THRESHOLD = 1000;
     /**
+     * Default NoSync.
+     */
+    public static final boolean DEFAULT_NO_SYNC = false;
+    /**
      * Default WriteOptions.
      */
-    public static final WriteOptions DEFAULTS = new WriteOptions(null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD);
+    public static final WriteOptions DEFAULTS = new WriteOptions(null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC, null, null);
 
     private final String database;
     private final WritePrecision precision;
     private final Integer gzipThreshold;
+    private final Boolean noSync;
     private final Map<String, String> defaultTags;
     private final Map<String, String> headers;
 
@@ -85,7 +90,7 @@ public final class WriteOptions {
     public WriteOptions(@Nullable final String database,
                         @Nullable final WritePrecision precision,
                         @Nullable final Integer gzipThreshold) {
-        this(database, precision, gzipThreshold, null);
+        this(database, precision, gzipThreshold, null, null, null);
     }
 
     /**
@@ -103,7 +108,26 @@ public final class WriteOptions {
                         @Nullable final WritePrecision precision,
                         @Nullable final Integer gzipThreshold,
                         @Nullable final Map<String, String> defaultTags) {
-        this(database, precision, gzipThreshold, defaultTags, null);
+        this(database, precision, gzipThreshold, null, defaultTags, null);
+    }
+
+    /**
+     * Construct WriteAPI options.
+     *
+     * @param database      The database to be used for InfluxDB operations.
+     *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
+     * @param precision     The precision to use for the timestamp of points.
+     *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     * @param gzipThreshold The threshold for compressing request body.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
+     * @param noSync        Skip waiting for WAL persistence on write.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_NO_SYNC}.
+     */
+    public WriteOptions(@Nullable final String database,
+                        @Nullable final WritePrecision precision,
+                        @Nullable final Integer gzipThreshold,
+                        @Nullable final Boolean noSync) {
+        this(database, precision, gzipThreshold, noSync, null, null);
     }
 
     /**
@@ -113,7 +137,7 @@ public final class WriteOptions {
      *                The headers specified here are preferred over the headers specified in the client configuration.
      */
     public WriteOptions(@Nullable final Map<String, String> headers) {
-        this(null, null, null, null, headers);
+        this(null, null, null, null, null, headers);
     }
 
     /**
@@ -135,9 +159,35 @@ public final class WriteOptions {
                         @Nullable final Integer gzipThreshold,
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers) {
+        this(database, precision, gzipThreshold, null, defaultTags, headers);
+    }
+
+    /**
+     * Construct WriteAPI options.
+     *
+     * @param database      The database to be used for InfluxDB operations.
+     *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
+     * @param precision     The precision to use for the timestamp of points.
+     *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     * @param gzipThreshold The threshold for compressing request body.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
+     * @param noSync        Skip waiting for WAL persistence on write.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_NO_SYNC}.
+     * @param defaultTags   Default tags to be added when writing points.
+     * @param headers       The headers to be added to write request.
+     *                      The headers specified here are preferred over the headers
+     *                      specified in the client configuration.
+     */
+    public WriteOptions(@Nullable final String database,
+                        @Nullable final WritePrecision precision,
+                        @Nullable final Integer gzipThreshold,
+                        @Nullable final Boolean noSync,
+                        @Nullable final Map<String, String> defaultTags,
+                        @Nullable final Map<String, String> headers) {
         this.database = database;
         this.precision = precision;
         this.gzipThreshold = gzipThreshold;
+        this.noSync = noSync;
         this.defaultTags = defaultTags == null ? Map.of() : defaultTags;
         this.headers = headers == null ? Map.of() : headers;
     }
@@ -190,6 +240,16 @@ public final class WriteOptions {
     }
 
     /**
+     * @param config with default value
+     * @return Skip waiting for WAL persistence on write.
+     */
+    public boolean noSyncSafe(@Nonnull final ClientConfig config) {
+        Arguments.checkNotNull(config, "config");
+        return noSync != null ? noSync
+                : (config.getWriteNoSync() != null ? config.getWriteNoSync() : DEFAULT_NO_SYNC);
+    }
+
+    /**
      * @return The headers to be added to write request.
      */
     @Nonnull
@@ -209,13 +269,14 @@ public final class WriteOptions {
         return Objects.equals(database, that.database)
                 && precision == that.precision
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
+                && Objects.equals(noSync, that.noSync)
                 && defaultTags.equals(that.defaultTags)
                 && headers.equals(that.headers);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(database, precision, gzipThreshold, defaultTags, headers);
+        return Objects.hash(database, precision, gzipThreshold, noSync, defaultTags, headers);
     }
 
     private boolean isNotDefined(final String option) {
@@ -231,6 +292,7 @@ public final class WriteOptions {
         private String database;
         private WritePrecision precision;
         private Integer gzipThreshold;
+        private Boolean noSync;
         private Map<String, String> defaultTags = new HashMap<>();
         private Map<String, String> headers = new HashMap<>();
 
@@ -274,6 +336,19 @@ public final class WriteOptions {
         }
 
         /**
+         * Sets whether to skip waiting for WAL persistence on write.
+         *
+         * @param noSync skip waiting for WAL persistence on write.
+         * @return this
+         */
+        @Nonnull
+        public Builder noSync(@Nonnull final Boolean noSync) {
+
+            this.noSync = noSync;
+            return this;
+        }
+
+        /**
          * Sets defaultTags.
          *
          * @param defaultTags to be used when writing points
@@ -310,6 +385,6 @@ public final class WriteOptions {
     }
 
     private WriteOptions(@Nonnull final Builder builder) {
-        this(builder.database, builder.precision, builder.gzipThreshold, builder.defaultTags, builder.headers);
+        this(builder.database, builder.precision, builder.gzipThreshold, builder.noSync, builder.defaultTags, builder.headers);
     }
 }

--- a/src/main/java/com/influxdb/v3/client/write/WritePrecisionConverter.java
+++ b/src/main/java/com/influxdb/v3/client/write/WritePrecisionConverter.java
@@ -1,0 +1,34 @@
+package com.influxdb.v3.client.write;
+
+public class WritePrecisionConverter {
+
+    public static String toV2ApiString(WritePrecision precision) {
+        switch (precision) {
+            case NS:
+                return "ns";
+            case US:
+                return "us";
+            case MS:
+                return "ms";
+            case S:
+                return "s";
+            default:
+                throw new IllegalArgumentException("Unsupported precision '" + precision + "'");
+        }
+    }
+
+    public static String toV3ApiString(WritePrecision precision) {
+        switch (precision) {
+            case NS:
+                return "nanosecond";
+            case US:
+                return "microsecond";
+            case MS:
+                return "millisecond";
+            case S:
+                return "second";
+            default:
+                throw new IllegalArgumentException("Unsupported precision '" + precision + "'");
+        }
+    }
+}

--- a/src/test/java/com/influxdb/v3/client/AbstractMockServerTest.java
+++ b/src/test/java/com/influxdb/v3/client/AbstractMockServerTest.java
@@ -54,6 +54,11 @@ public abstract class AbstractMockServerTest {
     }
 
     @Nonnull
+    protected MockResponse createEmptyResponse(final int responseCode) {
+        return new MockResponse().setResponseCode(responseCode);
+    }
+
+    @Nonnull
     protected MockResponse createResponse(final int responseCode) {
 
         return createResponseWithHeaders(responseCode, Map.of(

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -55,9 +55,9 @@ class WriteOptionsTest {
 
     @Test
     void optionsEqualAll() {
-        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512);
+        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512, true);
         WriteOptions optionsViaBuilder = new WriteOptions.Builder()
-                .database("my-database").precision(WritePrecision.S).gzipThreshold(512).build();
+                .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true).build();
 
         Assertions.assertThat(options).isEqualTo(optionsViaBuilder);
     }
@@ -115,13 +115,15 @@ class WriteOptionsTest {
                 .organization("my-org")
                 .writePrecision(WritePrecision.S)
                 .gzipThreshold(512)
+                .writeNoSync(false)
                 .build();
 
-        WriteOptions options = new WriteOptions("your-database", WritePrecision.US, 4096);
+        WriteOptions options = new WriteOptions("your-database", WritePrecision.US, 4096, true);
 
         Assertions.assertThat(options.databaseSafe(config)).isEqualTo("your-database");
         Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WritePrecision.US);
         Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(4096);
+        Assertions.assertThat(options.noSyncSafe(config)).isEqualTo(true);
     }
 
     @Test
@@ -170,6 +172,19 @@ class WriteOptionsTest {
         Assertions.assertThat(options.databaseSafe(config)).isEqualTo("my-database");
         Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WritePrecision.S);
         Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(4096);
+    }
+
+    @Test
+    void optionsOverrideWriteNoSync() {
+        ClientConfig config = configBuilder
+                .database("my-database")
+                .organization("my-org")
+                .writeNoSync(true)
+                .build();
+
+        WriteOptions options = new WriteOptions.Builder().noSync(false).build();
+
+        Assertions.assertThat(options.noSyncSafe(config)).isEqualTo(false);
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/write/WritePrecisionConverterTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WritePrecisionConverterTest.java
@@ -1,0 +1,43 @@
+package com.influxdb.v3.client.write;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WritePrecisionConverterTest {
+    @Test
+    void toV2ApiString() {
+        Map<WritePrecision, String> testCases = Map.of(
+                WritePrecision.NS, "ns",
+                WritePrecision.US, "us",
+                WritePrecision.MS, "ms",
+                WritePrecision.S, "s"
+        );
+
+        for (Map.Entry<WritePrecision, String> e : testCases.entrySet()) {
+            WritePrecision precision = e.getKey();
+            String expectedString = e.getValue();
+            String result = WritePrecisionConverter.toV2ApiString(precision);
+            assertEquals(expectedString, result, "Failed for precision: " + precision);
+        }
+    }
+
+    @Test
+    void toV3ApiString() {
+        Map<WritePrecision, String> tc = Map.of(
+                WritePrecision.NS, "nanosecond",
+                WritePrecision.US, "microsecond",
+                WritePrecision.MS, "millisecond",
+                WritePrecision.S, "second"
+        );
+
+        for (Map.Entry<WritePrecision, String> e : tc.entrySet()) {
+            WritePrecision precision = e.getKey();
+            String expectedString = e.getValue();
+            String result = WritePrecisionConverter.toV3ApiString(precision);
+            assertEquals(expectedString, result, "Failed for precision: " + precision);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Support fast writes without waiting for WAL persistence:
   - New write option (`WriteOptions.noSync`) added: `true` value means faster write but without the confirmation that
     the data was persisted. Default value: `false`.
   - **Supported by self-managed InfluxDB 3 Core and Enterprise servers only!**
   - Also configurable via connection string query parameter (`writeNoSync`).
   - Also configurable via environment variable (`INFLUX_WRITE_NO_SYNC`).
   - Long precision string values added from v3 HTTP API: `"nanosecond"`, `"microsecond"`, `"millisecond"`, `"second"` (in addition to the existing `"ns"`, `"us"`, `"ms"`, `"s"`).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
