### PR TITLE
feat: update netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <netty-handler.version>4.2.2.Final</netty-handler.version>
+        <netty-handler.version>4.2.3.Final</netty-handler.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
 
         <plugin.surefire.version>3.5.2</plugin.surefire.version>


### PR DESCRIPTION
Closes [#249](https://github.com/InfluxCommunity/influxdb3-java/issues/249)

## Proposed Changes

- Update netty version so the client can work with jdk-24.
- I want to add jdk-24 to CI build but cimg of jdk-24 is not out yet.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
