### PR TITLE
fix: migrate Maven OSS repository to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
         <site>
             <id>GitHubPages</id>


### PR DESCRIPTION
This PR migrate deployment from Sonatype OSS repository to Central Portal. For more info see: https://central.sonatype.org/pages/ossrh-eol/

The successful deployment to new repo: https://app.circleci.com/pipelines/github/InfluxCommunity/influxdb3-java/946/workflows/bee2b6a2-dba0-44d6-943a-960bc4a47833/jobs/5868