### PR TITLE
chore: explicitly close the vector after finish the processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#317](https://github.com/InfluxCommunity/influxdb3-java/pull/317): Fix Arrow memory leak when stream close fails due to thread interrupts.
+1. [#318](https://github.com/InfluxCommunity/influxdb3-java/pull/318): Explicit releasing of the VectorSchemaRoot.
 
 ## 1.6.0 [2025-11-14]
 

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -43,6 +43,7 @@ import io.grpc.Deadline;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.arrow.flight.CallOption;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
 import com.influxdb.v3.client.InfluxDBApiException;
@@ -216,7 +217,8 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
     public Stream<Map<String, Object>> queryRows(@Nonnull final String query,
                                                  @Nonnull final Map<String, Object> parameters,
                                                  @Nonnull final QueryOptions options) {
-        return queryDataAndProcess(query, parameters, options, VectorSchemaRootConverter.INSTANCE::getMapFromVectorSchemaRoot);
+        return queryDataAndProcess(query, parameters, options,
+                VectorSchemaRootConverter.INSTANCE::getMapFromVectorSchemaRoot);
     }
 
     @Nonnull
@@ -243,7 +245,10 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
                                            @Nonnull final Map<String, Object> parameters,
                                            @Nonnull final QueryOptions options) {
         return queryDataAndProcess(query, parameters, options,
-                (vector, rowNumber) -> VectorSchemaRootConverter.INSTANCE.toPointValues(rowNumber, vector.getFieldVectors()));
+                (vector, rowNumber) -> {
+                    List<FieldVector> fieldVectors = vector.getFieldVectors();
+                    return VectorSchemaRootConverter.INSTANCE.toPointValues(rowNumber, fieldVectors);
+                });
     }
 
     @Nonnull


### PR DESCRIPTION
## Proposed Changes

This pull request refactors the query methods in `InfluxDBClientImpl.java` to reduce code duplication when processing query responses into custom data objects.

The most significant change is the explicit closing of the `VectorSchemaRoot` by `onClose(vector::close)`. Although VectorSchemaRoot is automatically released by the FlightSqlClient, we now close it explicitly to add an extra layer of safety and ensure that all resources are properly freed.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
