### PR TITLE
chore: Add GitHub Actions to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Proposed Changes

This pull request updates the Dependabot configuration to include support for GitHub Actions, ensuring that dependencies for workflows are checked and updated automatically.

Dependabot configuration improvements:

* Added a new entry to `.github/dependabot.yml` to enable daily update checks for GitHub Actions dependencies, with a limit of 10 open pull requests.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
