### PR TITLE
feat: support partial writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 1.10.0 [unreleased]
 
-## 1.9.0 [2026-04-23]
-
 ### Breaking Changes
 
 1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Adds partial writes support and aligns write routing with v3 defaults.
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
    For InfluxDB Clustered version, set `useV2Api=true` for writing.
+
+## 1.9.0 [2026-04-23]
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## 1.9.0 [2026-04-23]
 
+### BREAKING CHANGES
+
+1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Adds partial writes support and aligns write routing with v3 defaults.
+   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
+   For InfluxDB Clustered version, set `useV2Api=true` for writing.
+
 ### Features
 
 1. [#360](https://github.com/InfluxCommunity/influxdb3-java/pull/360): Support passing interceptors to the Flight client.
 1. [#363](https://github.com/InfluxCommunity/influxdb3-java/pull/363): Support custom tag order via `tagOrder` write option.
    See [Sort tags by priority](https://docs.influxdata.com/influxdb3/enterprise/write-data/best-practices/schema-design/#sort-tags-by-query-priority) for more.
-1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Support partial writes via `acceptPartial` write option.
-   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 
 ## 1.8.0 [2026-02-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 1. [#360](https://github.com/InfluxCommunity/influxdb3-java/pull/360): Support passing interceptors to the Flight client.
 1. [#363](https://github.com/InfluxCommunity/influxdb3-java/pull/363): Support custom tag order via `tagOrder` write option.
    See [Sort tags by priority](https://docs.influxdata.com/influxdb3/enterprise/write-data/best-practices/schema-design/#sort-tags-by-query-priority) for more.
+1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Support partial writes via `acceptPartial` write option.
+   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 
 ## 1.8.0 [2026-02-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.9.0 [2026-04-23]
 
-### BREAKING CHANGES
+### Breaking Changes
 
 1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Adds partial writes support and aligns write routing with v3 defaults.
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ String record = "temperature,location=north value=60.0";
 client.writeRecord(record);
 ```
 
+#### Accept partial writes and inspect failed lines
+
+Partial writes are enabled by default.
+`acceptPartial` can be configured in three ways: client defaults via `WriteOptions`, connection string / environment variable / system property (`writeAcceptPartial` / `INFLUX_WRITE_ACCEPT_PARTIAL` / `influx.writeAcceptPartial`), or per-write `WriteOptions`.
+
+Set `acceptPartial(false)` to disable partial writes.
+With InfluxDB Core/Enterprise, when a write request fails due to one or more invalid lines, the error message starts with:
+
+- `partial write of line protocol occurred` when partial writes are enabled.
+- `parsing failed for write_lp endpoint` when partial writes are disabled.
+
+When partial writes are disabled, any rejected line causes all lines to be rejected.
+InfluxDB Clustered does not return this structured partial-write error format.
+
+#### Compatibility with InfluxDB Clustered
+
+For InfluxDB Clustered, enable `useV2Api` for writes.
+Like other write options, this can be configured in client code, connection string / environment variable / system property (`writeUseV2Api` / `INFLUX_WRITE_USE_V2_API` / `influx.writeUseV2Api`), or per-write `WriteOptions`.
+
+If `useV2Api` is set, `acceptPartial` is ignored because this compatibility mode does not support partial-write controls.
+Any rejected line causes all lines to be rejected.
+
 to query your data, you can use code like this:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ dependencies {
 
 ## Usage
 
+### Create client
+
 To start with the client, import the `com.influxdb.v3.client` package and create a `InfluxDBClient` by:
 
 ```java
@@ -91,7 +93,9 @@ public class IOxExample {
 }
 ```
 
-to insert data, you can use code like this:
+### Write
+
+To insert data, you can use code like this:
 
 ```java
 //
@@ -144,7 +148,7 @@ String record = "temperature,location=north value=60.0";
 client.writeRecord(record);
 ```
 
-### Accept partial writes and inspect failed lines
+#### Accept partial writes and inspect failed lines
 
 Partial writes are enabled by default.
 `acceptPartial` can be configured in three ways: client defaults via `WriteOptions`, connection string / environment variable / system property (`writeAcceptPartial` / `INFLUX_WRITE_ACCEPT_PARTIAL` / `influx.writeAcceptPartial`), or per-write `WriteOptions`.
@@ -158,7 +162,7 @@ With InfluxDB Core/Enterprise, when a write request fails due to one or more inv
 When partial writes are disabled, any rejected line causes all lines to be rejected.
 InfluxDB Clustered does not return this structured partial-write error format.
 
-### Compatibility with InfluxDB Clustered
+#### Compatibility with InfluxDB Clustered
 
 For InfluxDB Clustered, enable `useV2Api` for writes.
 Like other write options, this can be configured in client code, connection string / environment variable / system property (`writeUseV2Api` / `INFLUX_WRITE_USE_V2_API` / `influx.writeUseV2Api`), or per-write `WriteOptions`.
@@ -166,7 +170,9 @@ Like other write options, this can be configured in client code, connection stri
 If `useV2Api` is set, `acceptPartial` is ignored because this compatibility mode does not support partial-write controls.
 Any rejected line causes all lines to be rejected.
 
-to query your data, you can use code like this:
+### Query
+
+To query your data, you can use code like this:
 
 ```java
 //

--- a/README.md
+++ b/README.md
@@ -115,11 +115,9 @@ client.writePoint(
 );
 
 //
-// Write with partial acceptance
+// Write with partial acceptance (default behavior)
 //
-WriteOptions partialWrite = new WriteOptions.Builder()
-        .acceptPartial(true)
-        .build();
+WriteOptions partialWrite = new WriteOptions.Builder().build();
 try {
     client.writeRecords(List.of(
             "temperature,region=west value=20.0",
@@ -130,6 +128,14 @@ try {
     e.lineErrors().forEach(line ->
             System.out.printf("line=%s msg=%s lp=%s%n", line.lineNumber(), line.errorMessage(), line.originalLine()));
 }
+
+//
+// Write via v2 compatibility endpoint (InfluxDB Clustered)
+//
+WriteOptions useV2 = new WriteOptions.Builder()
+        .useV2Api(true)
+        .build();
+client.writeRecord("temperature,location=north value=60.0", useV2);
 
 //
 // Write by LineProtocol

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ String record = "temperature,location=north value=60.0";
 client.writeRecord(record);
 ```
 
-#### Accept partial writes and inspect failed lines
+### Accept partial writes and inspect failed lines
 
 Partial writes are enabled by default.
 `acceptPartial` can be configured in three ways: client defaults via `WriteOptions`, connection string / environment variable / system property (`writeAcceptPartial` / `INFLUX_WRITE_ACCEPT_PARTIAL` / `influx.writeAcceptPartial`), or per-write `WriteOptions`.
@@ -158,7 +158,7 @@ With InfluxDB Core/Enterprise, when a write request fails due to one or more inv
 When partial writes are disabled, any rejected line causes all lines to be rejected.
 InfluxDB Clustered does not return this structured partial-write error format.
 
-#### Compatibility with InfluxDB Clustered
+### Compatibility with InfluxDB Clustered
 
 For InfluxDB Clustered, enable `useV2Api` for writes.
 Like other write options, this can be configured in client code, connection string / environment variable / system property (`writeUseV2Api` / `INFLUX_WRITE_USE_V2_API` / `influx.writeUseV2Api`), or per-write `WriteOptions`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.InfluxDBPartialWriteException;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.influxdb.v3.client.Point;
 import com.influxdb.v3.client.write.WriteOptions;
@@ -112,6 +113,23 @@ client.writePoint(
                 .setField("value", 60.25),
         orderedTagWrite
 );
+
+//
+// Write with partial acceptance
+//
+WriteOptions partialWrite = new WriteOptions.Builder()
+        .acceptPartial(true)
+        .build();
+try {
+    client.writeRecords(List.of(
+            "temperature,region=west value=20.0",
+            "temperature,region=west value=\"bad\""
+    ), partialWrite);
+} catch (InfluxDBPartialWriteException e) {
+    // Inspect failed line details.
+    e.lineErrors().forEach(line ->
+            System.out.printf("line=%s msg=%s lp=%s%n", line.lineNumber(), line.errorMessage(), line.originalLine()));
+}
 
 //
 // Write by LineProtocol

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -557,6 +557,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>precision - timestamp precision when writing data</li>
      *   <li>gzipThreshold - payload size size for gzipping data</li>
      *   <li>writeNoSync - skip waiting for WAL persistence on write</li>
+     *   <li>writeAcceptPartial - accept partial writes</li>
      * </ul>
      *
      * @param connectionString connection string
@@ -590,6 +591,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>INFLUX_PRECISION - timestamp precision when writing data</li>
      *   <li>INFLUX_GZIP_THRESHOLD - payload size size for gzipping data</li>
      *   <li>INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write</li>
+     *   <li>INFLUX_WRITE_ACCEPT_PARTIAL - accept partial writes</li>
      * </ul>
      * Supported system properties:
      * <ul>
@@ -601,6 +603,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.precision - timestamp precision when writing data</li>
      *   <li>influx.gzipThreshold - payload size size for gzipping data</li>
      *   <li>influx.writeNoSync - skip waiting for WAL persistence on write</li>
+     *   <li>influx.writeAcceptPartial - accept partial writes</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -558,6 +558,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>gzipThreshold - payload size size for gzipping data</li>
      *   <li>writeNoSync - skip waiting for WAL persistence on write</li>
      *   <li>writeAcceptPartial - accept partial writes</li>
+     *   <li>writeUseV2Api - use v2 compatibility write endpoint</li>
      * </ul>
      *
      * @param connectionString connection string
@@ -592,6 +593,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>INFLUX_GZIP_THRESHOLD - payload size size for gzipping data</li>
      *   <li>INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write</li>
      *   <li>INFLUX_WRITE_ACCEPT_PARTIAL - accept partial writes</li>
+     *   <li>INFLUX_WRITE_USE_V2_API - use v2 compatibility write endpoint</li>
      * </ul>
      * Supported system properties:
      * <ul>
@@ -604,6 +606,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.gzipThreshold - payload size size for gzipping data</li>
      *   <li>influx.writeNoSync - skip waiting for WAL persistence on write</li>
      *   <li>influx.writeAcceptPartial - accept partial writes</li>
+     *   <li>influx.writeUseV2Api - use v2 compatibility write endpoint</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/InfluxDBPartialWriteException.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBPartialWriteException.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.influxdb.v3.client;
+
+import java.net.http.HttpHeaders;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * HTTP exception for partial write errors returned by InfluxDB 3 write endpoint.
+ * Contains parsed line-level write errors so callers can decide how to handle failed lines.
+ */
+public class InfluxDBPartialWriteException extends InfluxDBApiHttpException {
+
+    private final List<LineError> lineErrors;
+
+    /**
+     * Construct a new InfluxDBPartialWriteException.
+     *
+     * @param message    detail message
+     * @param headers    response headers
+     * @param statusCode response status code
+     * @param lineErrors line-level errors parsed from response body
+     */
+    public InfluxDBPartialWriteException(
+            @Nullable final String message,
+            @Nullable final HttpHeaders headers,
+            final int statusCode,
+            @Nonnull final List<LineError> lineErrors) {
+        super(message, headers, statusCode);
+        this.lineErrors = List.copyOf(lineErrors);
+    }
+
+    /**
+     * Line-level write errors.
+     *
+     * @return immutable list of line errors
+     */
+    @Nonnull
+    public List<LineError> lineErrors() {
+        return lineErrors;
+    }
+
+    /**
+     * Represents one failed line from a partial write response.
+     */
+    public static final class LineError {
+
+        private final Integer lineNumber;
+        private final String errorMessage;
+        private final String originalLine;
+
+        /**
+         * @param lineNumber  line number in the write payload; may be null if not provided by server
+         * @param errorMessage line-level error message
+         * @param originalLine original line protocol row; may be null if not provided by server
+         */
+        public LineError(@Nullable final Integer lineNumber,
+                         @Nonnull final String errorMessage,
+                         @Nullable final String originalLine) {
+            this.lineNumber = lineNumber;
+            this.errorMessage = errorMessage;
+            this.originalLine = originalLine;
+        }
+
+        /**
+         * @return line number or null if server didn't provide it
+         */
+        @Nullable
+        public Integer lineNumber() {
+            return lineNumber;
+        }
+
+        /**
+         * @return line-level error message
+         */
+        @Nonnull
+        public String errorMessage() {
+            return errorMessage;
+        }
+
+        /**
+         * @return original line protocol row or null if server didn't provide it
+         */
+        @Nullable
+        public String originalLine() {
+            return originalLine;
+        }
+    }
+}

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -58,6 +58,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>gzipThreshold</code> - threshold when gzip compression is used for writing points to InfluxDB</li>
  *     <li><code>writeNoSync</code> - skip waiting for WAL persistence on write</li>
  *     <li><code>writeAcceptPartial</code> - accept partial writes</li>
+ *     <li><code>writeUseV2Api</code> - use v2 compatibility write endpoint</li>
  *     <li><code>timeout</code> - <i>deprecated in 1.4.0</i> timeout when connecting to InfluxDB,
  *     please use more informative properties <code>writeTimeout</code> and <code>queryTimeout</code></li>
  *     <li><code>writeTimeout</code> - timeout when writing data to InfluxDB</li>
@@ -109,6 +110,7 @@ public final class ClientConfig {
     private final Integer gzipThreshold;
     private final Boolean writeNoSync;
     private final Boolean writeAcceptPartial;
+    private final Boolean writeUseV2Api;
     private final Map<String, String> defaultTags;
     @Deprecated
     private final Duration timeout;
@@ -218,6 +220,16 @@ public final class ClientConfig {
     @Nonnull
     public Boolean getWriteAcceptPartial() {
         return writeAcceptPartial;
+    }
+
+    /**
+     * Use v2 compatibility write endpoint?
+     *
+     * @return use v2 compatibility write endpoint
+     */
+    @Nonnull
+    public Boolean getWriteUseV2Api() {
+        return writeUseV2Api;
     }
 
     /**
@@ -383,6 +395,7 @@ public final class ClientConfig {
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
                 && Objects.equals(writeNoSync, that.writeNoSync)
                 && Objects.equals(writeAcceptPartial, that.writeAcceptPartial)
+                && Objects.equals(writeUseV2Api, that.writeUseV2Api)
                 && Objects.equals(defaultTags, that.defaultTags)
                 && Objects.equals(timeout, that.timeout)
                 && Objects.equals(writeTimeout, that.writeTimeout)
@@ -401,7 +414,7 @@ public final class ClientConfig {
     @Override
     public int hashCode() {
         return Objects.hash(host, Arrays.hashCode(token), authScheme, organization,
-                database, writePrecision, gzipThreshold, writeNoSync, writeAcceptPartial,
+                database, writePrecision, gzipThreshold, writeNoSync, writeAcceptPartial, writeUseV2Api,
                 timeout, writeTimeout, queryTimeout, allowHttpRedirects, disableServerCertificateValidation,
                 proxy, proxyUrl, authenticator, headers,
                 defaultTags, sslRootsFilePath, disableGRPCCompression, interceptors);
@@ -417,6 +430,7 @@ public final class ClientConfig {
                 .add("gzipThreshold=" + gzipThreshold)
                 .add("writeNoSync=" + writeNoSync)
                 .add("writeAcceptPartial=" + writeAcceptPartial)
+                .add("writeUseV2Api=" + writeUseV2Api)
                 .add("timeout=" + timeout)
                 .add("writeTimeout=" + writeTimeout)
                 .add("queryTimeout=" + queryTimeout)
@@ -447,6 +461,7 @@ public final class ClientConfig {
         private Integer gzipThreshold;
         private Boolean writeNoSync;
         private Boolean writeAcceptPartial;
+        private Boolean writeUseV2Api;
         private Map<String, String> defaultTags;
         @Deprecated
         private Duration timeout;
@@ -579,6 +594,19 @@ public final class ClientConfig {
         public Builder writeAcceptPartial(@Nullable final Boolean writeAcceptPartial) {
 
             this.writeAcceptPartial = writeAcceptPartial;
+            return this;
+        }
+
+        /**
+         * Sets whether to use v2 compatibility write endpoint.
+         *
+         * @param writeUseV2Api use v2 compatibility write endpoint
+         * @return this
+         */
+        @Nonnull
+        public Builder writeUseV2Api(@Nullable final Boolean writeUseV2Api) {
+
+            this.writeUseV2Api = writeUseV2Api;
             return this;
         }
 
@@ -831,6 +859,9 @@ public final class ClientConfig {
             if (parameters.containsKey("writeAcceptPartial")) {
                 this.writeAcceptPartial(Boolean.parseBoolean(parameters.get("writeAcceptPartial")));
             }
+            if (parameters.containsKey("writeUseV2Api")) {
+                this.writeUseV2Api(Boolean.parseBoolean(parameters.get("writeUseV2Api")));
+            }
             if (parameters.containsKey("disableGRPCCompression")) {
                 this.disableGRPCCompression(Boolean.parseBoolean(parameters.get("disableGRPCCompression")));
             }
@@ -889,6 +920,10 @@ public final class ClientConfig {
             final String writeAcceptPartial = get.apply("INFLUX_WRITE_ACCEPT_PARTIAL", "influx.writeAcceptPartial");
             if (writeAcceptPartial != null) {
                 this.writeAcceptPartial(Boolean.parseBoolean(writeAcceptPartial));
+            }
+            final String writeUseV2Api = get.apply("INFLUX_WRITE_USE_V2_API", "influx.writeUseV2Api");
+            if (writeUseV2Api != null) {
+                this.writeUseV2Api(Boolean.parseBoolean(writeUseV2Api));
             }
             final String writeTimeout = get.apply("INFLUX_WRITE_TIMEOUT", "influx.writeTimeout");
             if (writeTimeout != null) {
@@ -949,6 +984,9 @@ public final class ClientConfig {
         writeAcceptPartial = builder.writeAcceptPartial != null
                 ? builder.writeAcceptPartial
                 : WriteOptions.DEFAULT_ACCEPT_PARTIAL;
+        writeUseV2Api = builder.writeUseV2Api != null
+                ? builder.writeUseV2Api
+                : WriteOptions.DEFAULT_USE_V2_API;
         defaultTags = builder.defaultTags;
         timeout = builder.timeout != null ? builder.timeout : Duration.ofSeconds(WriteOptions.DEFAULT_WRITE_TIMEOUT);
         writeTimeout = builder.writeTimeout != null

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -57,6 +57,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>defaultTags</code> - defaultTags added when writing points to InfluxDB</li>
  *     <li><code>gzipThreshold</code> - threshold when gzip compression is used for writing points to InfluxDB</li>
  *     <li><code>writeNoSync</code> - skip waiting for WAL persistence on write</li>
+ *     <li><code>writeAcceptPartial</code> - accept partial writes</li>
  *     <li><code>timeout</code> - <i>deprecated in 1.4.0</i> timeout when connecting to InfluxDB,
  *     please use more informative properties <code>writeTimeout</code> and <code>queryTimeout</code></li>
  *     <li><code>writeTimeout</code> - timeout when writing data to InfluxDB</li>
@@ -107,6 +108,7 @@ public final class ClientConfig {
     private final WritePrecision writePrecision;
     private final Integer gzipThreshold;
     private final Boolean writeNoSync;
+    private final Boolean writeAcceptPartial;
     private final Map<String, String> defaultTags;
     @Deprecated
     private final Duration timeout;
@@ -206,6 +208,16 @@ public final class ClientConfig {
     @Nonnull
     public Boolean getWriteNoSync() {
         return writeNoSync;
+    }
+
+    /**
+     * Accept partial writes?
+     *
+     * @return accept partial writes
+     */
+    @Nonnull
+    public Boolean getWriteAcceptPartial() {
+        return writeAcceptPartial;
     }
 
     /**
@@ -370,6 +382,7 @@ public final class ClientConfig {
                 && writePrecision == that.writePrecision
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
                 && Objects.equals(writeNoSync, that.writeNoSync)
+                && Objects.equals(writeAcceptPartial, that.writeAcceptPartial)
                 && Objects.equals(defaultTags, that.defaultTags)
                 && Objects.equals(timeout, that.timeout)
                 && Objects.equals(writeTimeout, that.writeTimeout)
@@ -388,7 +401,7 @@ public final class ClientConfig {
     @Override
     public int hashCode() {
         return Objects.hash(host, Arrays.hashCode(token), authScheme, organization,
-                database, writePrecision, gzipThreshold, writeNoSync,
+                database, writePrecision, gzipThreshold, writeNoSync, writeAcceptPartial,
                 timeout, writeTimeout, queryTimeout, allowHttpRedirects, disableServerCertificateValidation,
                 proxy, proxyUrl, authenticator, headers,
                 defaultTags, sslRootsFilePath, disableGRPCCompression, interceptors);
@@ -403,6 +416,7 @@ public final class ClientConfig {
                 .add("writePrecision=" + writePrecision)
                 .add("gzipThreshold=" + gzipThreshold)
                 .add("writeNoSync=" + writeNoSync)
+                .add("writeAcceptPartial=" + writeAcceptPartial)
                 .add("timeout=" + timeout)
                 .add("writeTimeout=" + writeTimeout)
                 .add("queryTimeout=" + queryTimeout)
@@ -432,6 +446,7 @@ public final class ClientConfig {
         private WritePrecision writePrecision;
         private Integer gzipThreshold;
         private Boolean writeNoSync;
+        private Boolean writeAcceptPartial;
         private Map<String, String> defaultTags;
         @Deprecated
         private Duration timeout;
@@ -551,6 +566,19 @@ public final class ClientConfig {
         public Builder writeNoSync(@Nullable final Boolean writeNoSync) {
 
             this.writeNoSync = writeNoSync;
+            return this;
+        }
+
+        /**
+         * Sets whether to accept partial writes.
+         *
+         * @param writeAcceptPartial accept partial writes
+         * @return this
+         */
+        @Nonnull
+        public Builder writeAcceptPartial(@Nullable final Boolean writeAcceptPartial) {
+
+            this.writeAcceptPartial = writeAcceptPartial;
             return this;
         }
 
@@ -800,6 +828,9 @@ public final class ClientConfig {
             if (parameters.containsKey("writeNoSync")) {
                 this.writeNoSync(Boolean.parseBoolean(parameters.get("writeNoSync")));
             }
+            if (parameters.containsKey("writeAcceptPartial")) {
+                this.writeAcceptPartial(Boolean.parseBoolean(parameters.get("writeAcceptPartial")));
+            }
             if (parameters.containsKey("disableGRPCCompression")) {
                 this.disableGRPCCompression(Boolean.parseBoolean(parameters.get("disableGRPCCompression")));
             }
@@ -854,6 +885,10 @@ public final class ClientConfig {
             final String writeNoSync = get.apply("INFLUX_WRITE_NO_SYNC", "influx.writeNoSync");
             if (writeNoSync != null) {
                 this.writeNoSync(Boolean.parseBoolean(writeNoSync));
+            }
+            final String writeAcceptPartial = get.apply("INFLUX_WRITE_ACCEPT_PARTIAL", "influx.writeAcceptPartial");
+            if (writeAcceptPartial != null) {
+                this.writeAcceptPartial(Boolean.parseBoolean(writeAcceptPartial));
             }
             final String writeTimeout = get.apply("INFLUX_WRITE_TIMEOUT", "influx.writeTimeout");
             if (writeTimeout != null) {
@@ -911,6 +946,9 @@ public final class ClientConfig {
         writePrecision = builder.writePrecision != null ? builder.writePrecision : WriteOptions.DEFAULT_WRITE_PRECISION;
         gzipThreshold = builder.gzipThreshold != null ? builder.gzipThreshold : WriteOptions.DEFAULT_GZIP_THRESHOLD;
         writeNoSync = builder.writeNoSync != null ? builder.writeNoSync : WriteOptions.DEFAULT_NO_SYNC;
+        writeAcceptPartial = builder.writeAcceptPartial != null
+                ? builder.writeAcceptPartial
+                : WriteOptions.DEFAULT_ACCEPT_PARTIAL;
         defaultTags = builder.defaultTags;
         timeout = builder.timeout != null ? builder.timeout : Duration.ofSeconds(WriteOptions.DEFAULT_WRITE_TIMEOUT);
         writeTimeout = builder.writeTimeout != null

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -309,15 +309,22 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         String path;
         Map<String, String> queryParams;
         boolean noSync = options.noSyncSafe(config);
-        if (noSync) {
-            // Setting no_sync=true is supported only in the v3 API.
+        boolean acceptPartial = options.acceptPartialSafe(config);
+        boolean useV3Write = noSync || acceptPartial;
+        if (useV3Write) {
+            // no_sync=true and accept_partial=true are supported only in the v3 API.
             path = "api/v3/write_lp";
             queryParams = new HashMap<>() {{
                 put("org", config.getOrganization());
                 put("db", database);
                 put("precision", WritePrecisionConverter.toV3ApiString(precision));
-                put("no_sync", "true");
             }};
+            if (noSync) {
+                queryParams.put("no_sync", "true");
+            }
+            if (acceptPartial) {
+                queryParams.put("accept_partial", "true");
+            }
         } else {
             // By default, use the v2 API.
             path = "api/v2/write";
@@ -373,10 +380,12 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         try {
             restClient.request(path, HttpMethod.POST, body, queryParams, headers);
         } catch (InfluxDBApiHttpException e) {
-            if (noSync && e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
-                // Server does not support the v3 write API, can't use the NoSync option.
+            if (useV3Write && e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
+                // Server does not support the v3 write API, can't use v3-only write options.
                 throw new InfluxDBApiHttpException("Server doesn't support write with NoSync=true "
-                        + "(supported by InfluxDB 3 Core/Enterprise servers only).", e.headers(), e.statusCode());
+                        + "or AcceptPartial=true (supported by InfluxDB 3 Core/Enterprise servers only).",
+                        e.headers(),
+                        e.statusCode());
             }
             throw e;
         }

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -305,14 +305,21 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         }
 
         WritePrecision precision = options.precisionSafe(config);
+        options.validate(config);
 
         String path;
         Map<String, String> queryParams;
         boolean noSync = options.noSyncSafe(config);
         boolean acceptPartial = options.acceptPartialSafe(config);
-        boolean useV3Write = noSync || acceptPartial;
-        if (useV3Write) {
-            // no_sync=true and accept_partial=true are supported only in the v3 API.
+        boolean useV2Api = options.useV2ApiSafe(config);
+        if (useV2Api) {
+            path = "api/v2/write";
+            queryParams = new HashMap<>() {{
+                put("org", config.getOrganization());
+                put("bucket", database);
+                put("precision", WritePrecisionConverter.toV2ApiString(precision));
+            }};
+        } else {
             path = "api/v3/write_lp";
             queryParams = new HashMap<>() {{
                 put("org", config.getOrganization());
@@ -322,17 +329,9 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
             if (noSync) {
                 queryParams.put("no_sync", "true");
             }
-            if (acceptPartial) {
-                queryParams.put("accept_partial", "true");
+            if (!acceptPartial) {
+                queryParams.put("accept_partial", "false");
             }
-        } else {
-            // By default, use the v2 API.
-            path = "api/v2/write";
-            queryParams = new HashMap<>() {{
-                put("org", config.getOrganization());
-                put("bucket", database);
-                put("precision", WritePrecisionConverter.toV2ApiString(precision));
-            }};
         }
 
         Map<String, String> defaultTags = options.defaultTagsSafe(config);
@@ -380,10 +379,9 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         try {
             restClient.request(path, HttpMethod.POST, body, queryParams, headers);
         } catch (InfluxDBApiHttpException e) {
-            if (useV3Write && e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
-                // Server does not support the v3 write API, can't use v3-only write options.
-                throw new InfluxDBApiHttpException("Server doesn't support write with NoSync=true "
-                        + "or AcceptPartial=true (supported by InfluxDB 3 Core/Enterprise servers only).",
+            if (!useV2Api && e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
+                throw new InfluxDBApiHttpException("Server doesn't support v3 write API. "
+                        + "Use WriteOptions.Builder.useV2Api(true) for v2 compatibility endpoint.",
                         e.headers(),
                         e.statusCode());
             }

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -46,6 +46,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -243,7 +244,8 @@ final class RestClient implements AutoCloseable {
             }
 
             String message = String.format("HTTP status code: %d; Message: %s", statusCode, reason);
-            List<InfluxDBPartialWriteException.LineError> lineErrors = parsePartialWriteLineErrors(body, contentType);
+            List<InfluxDBPartialWriteException.LineError> lineErrors =
+                    parsePartialWriteLineErrors(path, body, contentType);
             if (!lineErrors.isEmpty()) {
                 throw new InfluxDBPartialWriteException(message, response.headers(), response.statusCode(), lineErrors);
             }
@@ -284,11 +286,7 @@ final class RestClient implements AutoCloseable {
             if (error != null && dataNode != null && dataNode.isArray()) {
                 final StringBuilder message = new StringBuilder(error);
                 boolean hasDetails = false;
-                for (JsonNode item : dataNode) {
-                    final String detail = errFormatDataArrayDetail(item);
-                    if (detail == null) {
-                        continue;
-                    }
+                for (String detail : errFormatDataArrayDetails(dataNode)) {
                     if (!hasDetails) {
                         message.append(':');
                         hasDetails = true;
@@ -314,8 +312,12 @@ final class RestClient implements AutoCloseable {
 
     @Nonnull
     private List<InfluxDBPartialWriteException.LineError> parsePartialWriteLineErrors(
+            @Nonnull final String path,
             @Nonnull final String body,
             @Nullable final String contentType) {
+        if (!isWriteEndpoint(path)) {
+            return List.of();
+        }
 
         if (body.isEmpty()) {
             return List.of();
@@ -340,9 +342,14 @@ final class RestClient implements AutoCloseable {
             }
 
             if (dataNode.isArray()) {
+                final ErrDataArrayItem[] parsed = errReadDataArray(dataNode);
+                if (parsed == null) {
+                    return List.of();
+                }
+
                 final List<InfluxDBPartialWriteException.LineError> lineErrors = new ArrayList<>();
-                for (JsonNode item : dataNode) {
-                    InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(item);
+                for (ErrDataArrayItem item : parsed) {
+                    final InfluxDBPartialWriteException.LineError lineError = errToLineError(item);
                     if (lineError != null) {
                         lineErrors.add(lineError);
                     }
@@ -351,8 +358,13 @@ final class RestClient implements AutoCloseable {
             }
 
             if (dataNode.isObject()) {
-                InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(dataNode);
-                return lineError == null ? List.of() : List.of(lineError);
+                try {
+                    final ErrDataArrayItem item = objectMapper.treeToValue(dataNode, ErrDataArrayItem.class);
+                    final InfluxDBPartialWriteException.LineError lineError = errToLineError(item);
+                    return lineError == null ? List.of() : List.of(lineError);
+                } catch (JsonProcessingException e) {
+                    return List.of();
+                }
             }
 
             return List.of();
@@ -362,12 +374,25 @@ final class RestClient implements AutoCloseable {
         }
     }
 
+    private boolean isWriteEndpoint(@Nonnull final String path) {
+        return "api/v2/write".equals(path) || "api/v3/write_lp".equals(path);
+    }
+
     @Nullable
     private String errNonEmptyText(@Nullable final JsonNode node) {
         if (node == null || node.isNull()) {
             return null;
         }
-        final String value = node.asText();
+
+        final String value;
+        if (node.isTextual()) {
+            value = node.asText();
+        } else if (node.isNumber() || node.isBoolean()) {
+            value = node.asText();
+        } else {
+            value = node.toString();
+        }
+
         return value.isEmpty() ? null : value;
     }
 
@@ -380,65 +405,66 @@ final class RestClient implements AutoCloseable {
     }
 
     @Nullable
-    private String errFormatDataArrayDetail(@Nullable final JsonNode item) {
-        if (!item.isObject()) {
-            return null;
+    private List<String> errFormatDataArrayDetails(@Nonnull final JsonNode dataNode) {
+        final ErrDataArrayItem[] parsed = errReadDataArray(dataNode);
+        if (parsed != null) {
+            final List<String> details = new ArrayList<>();
+            for (ErrDataArrayItem item : parsed) {
+                final InfluxDBPartialWriteException.LineError lineError = errToLineError(item);
+                if (lineError == null) {
+                    continue;
+                }
+
+                if (lineError.lineNumber() != null
+                        && lineError.originalLine() != null
+                        && !lineError.originalLine().isEmpty()) {
+                    details.add("line " + lineError.lineNumber() + ": "
+                            + lineError.errorMessage() + " (" + lineError.originalLine() + ")");
+                } else {
+                    details.add(lineError.errorMessage());
+                }
+            }
+            return details;
         }
 
-        final String errorMessage = errNonEmptyField(item, "error_message");
-        if (errorMessage == null) {
-            return null;
-        }
-
-        if (item.hasNonNull("line_number")) {
-            final String originalLine = errNonEmptyField(item, "original_line");
-            if (originalLine != null) {
-                final String lineNumber = item.get("line_number").asText();
-                return "line " + lineNumber + ": " + errorMessage + " (" + originalLine + ")";
+        final List<String> details = new ArrayList<>();
+        for (JsonNode item : dataNode) {
+            final String raw = errNonEmptyText(item);
+            if (raw != null) {
+                details.add(raw);
             }
         }
-        return errorMessage;
+        return details;
     }
 
     @Nullable
-    private InfluxDBPartialWriteException.LineError errParseDataArrayLineError(@Nonnull final JsonNode item) {
-        if (!item.isObject()) {
+    private ErrDataArrayItem[] errReadDataArray(@Nonnull final JsonNode dataNode) {
+        try {
+            return objectMapper.treeToValue(dataNode, ErrDataArrayItem[].class);
+        } catch (JsonProcessingException e) {
             return null;
         }
-
-        final String errorMessage = errNonEmptyField(item, "error_message");
-        if (errorMessage == null) {
-            return null;
-        }
-
-        final Integer lineNumber = errParseLineNumber(item);
-        final String originalLine = errNonEmptyField(item, "original_line");
-
-        return new InfluxDBPartialWriteException.LineError(lineNumber, errorMessage, originalLine);
     }
 
     @Nullable
-    private Integer errParseLineNumber(@Nonnull final JsonNode item) {
-        if (!item.hasNonNull("line_number")) {
+    private InfluxDBPartialWriteException.LineError errToLineError(@Nullable final ErrDataArrayItem item) {
+        if (item == null || item.errorMessage == null || item.errorMessage.isEmpty()) {
             return null;
         }
 
-        final JsonNode lineNumber = item.get("line_number");
-        if (lineNumber.isIntegralNumber()) {
-            return lineNumber.intValue();
-        }
-        if (lineNumber.isTextual()) {
-            final String value = lineNumber.asText();
-            if (value.isEmpty()) {
-                return null;
-            }
-            try {
-                return Integer.parseInt(value);
-            } catch (NumberFormatException e) {
-                return null;
-            }
-        }
-        return null;
+        final String originalLine = (item.originalLine == null || item.originalLine.isEmpty()) ? null : item.originalLine;
+        return new InfluxDBPartialWriteException.LineError(item.lineNumber, item.errorMessage, originalLine);
+    }
+
+    private static final class ErrDataArrayItem {
+        @JsonProperty("error_message")
+        private String errorMessage;
+
+        @JsonProperty("line_number")
+        private Integer lineNumber;
+
+        @JsonProperty("original_line")
+        private String originalLine;
     }
 
     private X509TrustManager getX509TrustManagerFromFile(@Nonnull final String filePath) {

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -335,18 +335,27 @@ final class RestClient implements AutoCloseable {
 
             final String error = errNonEmptyField(root, "error");
             final JsonNode dataNode = root.get("data");
-            if (error == null || dataNode == null || !dataNode.isArray()) {
+            if (error == null || dataNode == null) {
                 return List.of();
             }
 
-            final List<InfluxDBPartialWriteException.LineError> lineErrors = new ArrayList<>();
-            for (JsonNode item : dataNode) {
-                InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(item);
-                if (lineError != null) {
-                    lineErrors.add(lineError);
+            if (dataNode.isArray()) {
+                final List<InfluxDBPartialWriteException.LineError> lineErrors = new ArrayList<>();
+                for (JsonNode item : dataNode) {
+                    InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(item);
+                    if (lineError != null) {
+                        lineErrors.add(lineError);
+                    }
                 }
+                return lineErrors;
             }
-            return lineErrors;
+
+            if (dataNode.isObject()) {
+                InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(dataNode);
+                return lineError == null ? List.of() : List.of(lineError);
+            }
+
+            return List.of();
         } catch (JsonProcessingException e) {
             LOG.debug("Can't parse line errors from response body {}", body, e);
             return List.of();

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -299,9 +299,13 @@ final class RestClient implements AutoCloseable {
 
             // Core/Enterprise object format:
             // {"error":"...","data":{"error_message":"..."}}
-            final String errorMessage = errNonEmptyField(dataNode, "error_message");
-            if (errorMessage != null) {
-                return errorMessage;
+            if (isV3PartialWriteError(error) && dataNode != null && dataNode.isObject()) {
+                final StringBuilder message = new StringBuilder(error);
+                final String errorMessage = errNonEmptyField(dataNode, "error_message");
+                if (errorMessage != null) {
+                    message.append(":\n\t").append(errorMessage);
+                }
+                return message.toString();
             }
 
             return error;

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -452,7 +452,8 @@ final class RestClient implements AutoCloseable {
             return null;
         }
 
-        final String originalLine = (item.originalLine == null || item.originalLine.isEmpty()) ? null : item.originalLine;
+        final String originalLine =
+                (item.originalLine == null || item.originalLine.isEmpty()) ? null : item.originalLine;
         return new InfluxDBPartialWriteException.LineError(item.lineNumber, item.errorMessage, originalLine);
     }
 

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -36,6 +36,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -245,7 +246,7 @@ final class RestClient implements AutoCloseable {
 
             String message = String.format("HTTP status code: %d; Message: %s", statusCode, reason);
             List<InfluxDBPartialWriteException.LineError> lineErrors =
-                    parsePartialWriteLineErrors(path, body, contentType);
+                    parsePartialWriteLineErrors(body, contentType);
             if (!lineErrors.isEmpty()) {
                 throw new InfluxDBPartialWriteException(message, response.headers(), response.statusCode(), lineErrors);
             }
@@ -312,13 +313,8 @@ final class RestClient implements AutoCloseable {
 
     @Nonnull
     private List<InfluxDBPartialWriteException.LineError> parsePartialWriteLineErrors(
-            @Nonnull final String path,
             @Nonnull final String body,
             @Nullable final String contentType) {
-        if (!isWriteEndpoint(path)) {
-            return List.of();
-        }
-
         if (body.isEmpty()) {
             return List.of();
         }
@@ -337,7 +333,7 @@ final class RestClient implements AutoCloseable {
 
             final String error = errNonEmptyField(root, "error");
             final JsonNode dataNode = root.get("data");
-            if (error == null || dataNode == null) {
+            if (!isV3PartialWriteError(error) || dataNode == null) {
                 return List.of();
             }
 
@@ -374,8 +370,13 @@ final class RestClient implements AutoCloseable {
         }
     }
 
-    private boolean isWriteEndpoint(@Nonnull final String path) {
-        return "api/v2/write".equals(path) || "api/v3/write_lp".equals(path);
+    private boolean isV3PartialWriteError(@Nullable final String errorMessage) {
+        if (errorMessage == null || errorMessage.isEmpty()) {
+            return false;
+        }
+        String normalized = errorMessage.toLowerCase(Locale.ROOT);
+        return normalized.contains("partial write of line protocol occurred")
+                || normalized.contains("parsing failed for write_lp endpoint");
     }
 
     @Nullable

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -404,7 +404,7 @@ final class RestClient implements AutoCloseable {
         return errNonEmptyText(object.get(fieldName));
     }
 
-    @Nullable
+    @Nonnull
     private List<String> errFormatDataArrayDetails(@Nonnull final JsonNode dataNode) {
         final ErrDataArrayItem[] parsed = errReadDataArray(dataNode);
         if (parsed != null) {

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import com.influxdb.v3.client.InfluxDBApiException;
 import com.influxdb.v3.client.InfluxDBApiHttpException;
+import com.influxdb.v3.client.InfluxDBPartialWriteException;
 import com.influxdb.v3.client.config.ClientConfig;
 
 final class RestClient implements AutoCloseable {
@@ -219,7 +220,8 @@ final class RestClient implements AutoCloseable {
         if (statusCode < 200 || statusCode >= 300) {
             String reason;
             String body = response.body();
-            reason = formatErrorMessage(body, response.headers().firstValue("Content-Type").orElse(null));
+            String contentType = response.headers().firstValue("Content-Type").orElse(null);
+            reason = formatErrorMessage(body, contentType);
 
             if (reason == null) {
                 reason = "";
@@ -241,6 +243,10 @@ final class RestClient implements AutoCloseable {
             }
 
             String message = String.format("HTTP status code: %d; Message: %s", statusCode, reason);
+            List<InfluxDBPartialWriteException.LineError> lineErrors = parsePartialWriteLineErrors(body, contentType);
+            if (!lineErrors.isEmpty()) {
+                throw new InfluxDBPartialWriteException(message, response.headers(), response.statusCode(), lineErrors);
+            }
             throw new InfluxDBApiHttpException(message, response.headers(), response.statusCode());
         }
 
@@ -306,6 +312,47 @@ final class RestClient implements AutoCloseable {
         }
     }
 
+    @Nonnull
+    private List<InfluxDBPartialWriteException.LineError> parsePartialWriteLineErrors(
+            @Nonnull final String body,
+            @Nullable final String contentType) {
+
+        if (body.isEmpty()) {
+            return List.of();
+        }
+
+        if (contentType != null
+                && !contentType.isEmpty()
+                && !contentType.regionMatches(true, 0, "application/json", 0, "application/json".length())) {
+            return List.of();
+        }
+
+        try {
+            final JsonNode root = objectMapper.readTree(body);
+            if (!root.isObject()) {
+                return List.of();
+            }
+
+            final String error = errNonEmptyField(root, "error");
+            final JsonNode dataNode = root.get("data");
+            if (error == null || dataNode == null || !dataNode.isArray()) {
+                return List.of();
+            }
+
+            final List<InfluxDBPartialWriteException.LineError> lineErrors = new ArrayList<>();
+            for (JsonNode item : dataNode) {
+                InfluxDBPartialWriteException.LineError lineError = errParseDataArrayLineError(item);
+                if (lineError != null) {
+                    lineErrors.add(lineError);
+                }
+            }
+            return lineErrors;
+        } catch (JsonProcessingException e) {
+            LOG.debug("Can't parse line errors from response body {}", body, e);
+            return List.of();
+        }
+    }
+
     @Nullable
     private String errNonEmptyText(@Nullable final JsonNode node) {
         if (node == null || node.isNull()) {
@@ -342,6 +389,47 @@ final class RestClient implements AutoCloseable {
             }
         }
         return errorMessage;
+    }
+
+    @Nullable
+    private InfluxDBPartialWriteException.LineError errParseDataArrayLineError(@Nullable final JsonNode item) {
+        if (item == null || !item.isObject()) {
+            return null;
+        }
+
+        final String errorMessage = errNonEmptyField(item, "error_message");
+        if (errorMessage == null) {
+            return null;
+        }
+
+        final Integer lineNumber = errParseLineNumber(item);
+        final String originalLine = errNonEmptyField(item, "original_line");
+
+        return new InfluxDBPartialWriteException.LineError(lineNumber, errorMessage, originalLine);
+    }
+
+    @Nullable
+    private Integer errParseLineNumber(@Nonnull final JsonNode item) {
+        if (!item.hasNonNull("line_number")) {
+            return null;
+        }
+
+        final JsonNode lineNumber = item.get("line_number");
+        if (lineNumber.isIntegralNumber()) {
+            return lineNumber.intValue();
+        }
+        if (lineNumber.isTextual()) {
+            final String value = lineNumber.asText();
+            if (value.isEmpty()) {
+                return null;
+            }
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private X509TrustManager getX509TrustManagerFromFile(@Nonnull final String filePath) {

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -262,9 +262,7 @@ final class RestClient implements AutoCloseable {
             return null;
         }
 
-        if (contentType != null
-                && !contentType.isEmpty()
-                && !contentType.regionMatches(true, 0, "application/json", 0, "application/json".length())) {
+        if (!errIsJsonLikeContentType(contentType)) {
             return null;
         }
 
@@ -300,12 +298,10 @@ final class RestClient implements AutoCloseable {
             // Core/Enterprise object format:
             // {"error":"...","data":{"error_message":"..."}}
             if (isV3PartialWriteError(error) && dataNode != null && dataNode.isObject()) {
-                final StringBuilder message = new StringBuilder(error);
                 final String errorMessage = errNonEmptyField(dataNode, "error_message");
-                if (errorMessage != null) {
-                    message.append(":\n\t").append(errorMessage);
-                }
-                return message.toString();
+                return errorMessage == null
+                        ? error
+                        : error + ":\n\t" + errorMessage;
             }
 
             return error;
@@ -323,9 +319,7 @@ final class RestClient implements AutoCloseable {
             return List.of();
         }
 
-        if (contentType != null
-                && !contentType.isEmpty()
-                && !contentType.regionMatches(true, 0, "application/json", 0, "application/json".length())) {
+        if (!errIsJsonLikeContentType(contentType)) {
             return List.of();
         }
 
@@ -381,6 +375,12 @@ final class RestClient implements AutoCloseable {
         String normalized = errorMessage.toLowerCase(Locale.ROOT);
         return normalized.contains("partial write of line protocol occurred")
                 || normalized.contains("parsing failed for write_lp endpoint");
+    }
+
+    private boolean errIsJsonLikeContentType(@Nullable final String contentType) {
+        return contentType == null
+                || contentType.isEmpty()
+                || contentType.regionMatches(true, 0, "application/json", 0, "application/json".length());
     }
 
     @Nullable

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -401,8 +401,8 @@ final class RestClient implements AutoCloseable {
     }
 
     @Nullable
-    private InfluxDBPartialWriteException.LineError errParseDataArrayLineError(@Nullable final JsonNode item) {
-        if (item == null || !item.isObject()) {
+    private InfluxDBPartialWriteException.LineError errParseDataArrayLineError(@Nonnull final JsonNode item) {
+        if (!item.isObject()) {
             return null;
         }
 

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -43,6 +43,9 @@ import com.influxdb.v3.client.internal.Arguments;
  *     <li><code>precision</code> - specifies the precision to use for the timestamp of points</li>
  *     <li><code>defaultTags</code> - specifies tags to be added by default to all write operations using points.</li>
  *     <li><code>tagOrder</code> - specifies preferred tag order for point serialization.</li>
+ *     <li><code>noSync</code> - skip waiting for WAL persistence on write</li>
+ *     <li><code>acceptPartial</code> - accept partial writes</li>
+ *     <li><code>useV2Api</code> - use v2 compatibility write endpoint</li>
  *     <li><code>headers</code> - specifies the headers to be added to write request</li>
  * </ul>
  * <p>
@@ -71,7 +74,11 @@ public final class WriteOptions {
     /**
      * Default AcceptPartial.
      */
-    public static final boolean DEFAULT_ACCEPT_PARTIAL = false;
+    public static final boolean DEFAULT_ACCEPT_PARTIAL = true;
+    /**
+     * Default UseV2Api.
+     */
+    public static final boolean DEFAULT_USE_V2_API = false;
 
   /**
    * Default timeout for writes in seconds. Set to {@value}
@@ -86,13 +93,14 @@ public final class WriteOptions {
     @Deprecated(forRemoval = true)
     public static final WriteOptions DEFAULTS = new WriteOptions(
             null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC, DEFAULT_ACCEPT_PARTIAL,
-            null, null, null);
+            DEFAULT_USE_V2_API, null, null, null);
 
     private final String database;
     private final WritePrecision precision;
     private final Integer gzipThreshold;
     private final Boolean noSync;
     private final Boolean acceptPartial;
+    private final Boolean useV2Api;
     private final Map<String, String> defaultTags;
     private final List<String> tagOrder;
     private final Map<String, String> headers;
@@ -105,7 +113,7 @@ public final class WriteOptions {
      */
     public static WriteOptions defaultWriteOptions() {
         return new WriteOptions(null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC,
-                DEFAULT_ACCEPT_PARTIAL,
+                DEFAULT_ACCEPT_PARTIAL, DEFAULT_USE_V2_API,
                 null, null, null);
     }
 
@@ -216,7 +224,7 @@ public final class WriteOptions {
                         @Nullable final Boolean noSync,
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers) {
-        this(database, precision, gzipThreshold, noSync, null, defaultTags, headers, null);
+        this(database, precision, gzipThreshold, noSync, null, null, defaultTags, headers, null);
     }
 
     /**
@@ -247,11 +255,46 @@ public final class WriteOptions {
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers,
                         @Nullable final List<String> tagOrder) {
+        this(database, precision, gzipThreshold, noSync, acceptPartial, null, defaultTags, headers, tagOrder);
+    }
+
+    /**
+     * Construct WriteAPI options.
+     *
+     * @param database      The database to be used for InfluxDB operations.
+     *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
+     * @param precision     The precision to use for the timestamp of points.
+     *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     * @param gzipThreshold The threshold for compressing request body.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
+     * @param noSync        Skip waiting for WAL persistence on write.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_NO_SYNC}.
+     * @param acceptPartial Request partial write acceptance.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_ACCEPT_PARTIAL}.
+     * @param useV2Api      Use v2 compatibility write endpoint.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_USE_V2_API}.
+     * @param defaultTags   Default tags to be added when writing points.
+     * @param headers       The headers to be added to write request.
+     *                      The headers specified here are preferred over the headers
+     *                      specified in the client configuration.
+     * @param tagOrder      Preferred order of tags in line protocol serialization.
+     *                      Null or empty tag names are ignored.
+     */
+    public WriteOptions(@Nullable final String database,
+                        @Nullable final WritePrecision precision,
+                        @Nullable final Integer gzipThreshold,
+                        @Nullable final Boolean noSync,
+                        @Nullable final Boolean acceptPartial,
+                        @Nullable final Boolean useV2Api,
+                        @Nullable final Map<String, String> defaultTags,
+                        @Nullable final Map<String, String> headers,
+                        @Nullable final List<String> tagOrder) {
         this.database = database;
         this.precision = precision;
         this.gzipThreshold = gzipThreshold;
         this.noSync = noSync;
         this.acceptPartial = acceptPartial;
+        this.useV2Api = useV2Api;
         this.defaultTags = defaultTags == null ? Map.of() : defaultTags;
         this.tagOrder = sanitizeTagOrder(tagOrder);
         this.headers = headers == null ? Map.of() : headers;
@@ -282,7 +325,7 @@ public final class WriteOptions {
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers,
                         @Nullable final List<String> tagOrder) {
-        this(database, precision, gzipThreshold, noSync, null, defaultTags, headers, tagOrder);
+        this(database, precision, gzipThreshold, noSync, null, null, defaultTags, headers, tagOrder);
     }
 
     /**
@@ -351,6 +394,27 @@ public final class WriteOptions {
     }
 
     /**
+     * @param config with default value
+     * @return Use v2 compatibility write endpoint.
+     */
+    public boolean useV2ApiSafe(@Nonnull final ClientConfig config) {
+        Arguments.checkNotNull(config, "config");
+        return useV2Api != null ? useV2Api : config.getWriteUseV2Api();
+    }
+
+    /**
+     * Validate write option combinations.
+     *
+     * @param config with default values
+     */
+    public void validate(@Nonnull final ClientConfig config) {
+        Arguments.checkNotNull(config, "config");
+        if (useV2ApiSafe(config) && noSyncSafe(config)) {
+            throw new IllegalArgumentException("invalid write options: NoSync cannot be used in V2 API");
+        }
+    }
+
+    /**
      * @return The headers to be added to write request.
      */
     @Nonnull
@@ -380,6 +444,7 @@ public final class WriteOptions {
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
                 && Objects.equals(noSync, that.noSync)
                 && Objects.equals(acceptPartial, that.acceptPartial)
+                && Objects.equals(useV2Api, that.useV2Api)
                 && defaultTags.equals(that.defaultTags)
                 && tagOrder.equals(that.tagOrder)
                 && headers.equals(that.headers);
@@ -387,7 +452,7 @@ public final class WriteOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(database, precision, gzipThreshold, noSync, acceptPartial, defaultTags, tagOrder,
+        return Objects.hash(database, precision, gzipThreshold, noSync, acceptPartial, useV2Api, defaultTags, tagOrder,
                 headers);
     }
 
@@ -418,6 +483,7 @@ public final class WriteOptions {
         private Integer gzipThreshold;
         private Boolean noSync;
         private Boolean acceptPartial;
+        private Boolean useV2Api;
         private Map<String, String> defaultTags = new HashMap<>();
         private List<String> tagOrder = List.of();
         private Map<String, String> headers = new HashMap<>();
@@ -488,6 +554,19 @@ public final class WriteOptions {
         }
 
         /**
+         * Sets whether to use v2 compatibility write endpoint.
+         *
+         * @param useV2Api use v2 compatibility write endpoint
+         * @return this
+         */
+        @Nonnull
+        public Builder useV2Api(@Nonnull final Boolean useV2Api) {
+
+            this.useV2Api = useV2Api;
+            return this;
+        }
+
+        /**
          * Sets defaultTags.
          *
          * @param defaultTags to be used when writing points
@@ -537,6 +616,7 @@ public final class WriteOptions {
 
     private WriteOptions(@Nonnull final Builder builder) {
         this(builder.database, builder.precision, builder.gzipThreshold, builder.noSync, builder.acceptPartial,
+                builder.useV2Api,
                 builder.defaultTags, builder.headers, builder.tagOrder);
     }
 }

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -338,8 +338,7 @@ public final class WriteOptions {
      */
     public boolean noSyncSafe(@Nonnull final ClientConfig config) {
         Arguments.checkNotNull(config, "config");
-        return noSync != null ? noSync
-                : (config.getWriteNoSync() != null ? config.getWriteNoSync() : DEFAULT_NO_SYNC);
+        return noSync != null ? noSync : config.getWriteNoSync();
     }
 
     /**

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -348,10 +348,7 @@ public final class WriteOptions {
      */
     public boolean acceptPartialSafe(@Nonnull final ClientConfig config) {
         Arguments.checkNotNull(config, "config");
-        return acceptPartial != null ? acceptPartial
-                : (config.getWriteAcceptPartial() != null
-                ? config.getWriteAcceptPartial()
-                : DEFAULT_ACCEPT_PARTIAL);
+        return acceptPartial != null ? acceptPartial : config.getWriteAcceptPartial();
     }
 
     /**

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -68,6 +68,10 @@ public final class WriteOptions {
      * Default NoSync.
      */
     public static final boolean DEFAULT_NO_SYNC = false;
+    /**
+     * Default AcceptPartial.
+     */
+    public static final boolean DEFAULT_ACCEPT_PARTIAL = false;
 
   /**
    * Default timeout for writes in seconds. Set to {@value}
@@ -81,12 +85,14 @@ public final class WriteOptions {
 
     @Deprecated(forRemoval = true)
     public static final WriteOptions DEFAULTS = new WriteOptions(
-            null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC, null, null, null);
+            null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC, DEFAULT_ACCEPT_PARTIAL,
+            null, null, null);
 
     private final String database;
     private final WritePrecision precision;
     private final Integer gzipThreshold;
     private final Boolean noSync;
+    private final Boolean acceptPartial;
     private final Map<String, String> defaultTags;
     private final List<String> tagOrder;
     private final Map<String, String> headers;
@@ -99,6 +105,7 @@ public final class WriteOptions {
      */
     public static WriteOptions defaultWriteOptions() {
         return new WriteOptions(null, DEFAULT_WRITE_PRECISION, DEFAULT_GZIP_THRESHOLD, DEFAULT_NO_SYNC,
+                DEFAULT_ACCEPT_PARTIAL,
                 null, null, null);
     }
 
@@ -152,7 +159,7 @@ public final class WriteOptions {
                         @Nullable final WritePrecision precision,
                         @Nullable final Integer gzipThreshold,
                         @Nullable final Boolean noSync) {
-        this(database, precision, gzipThreshold, noSync, null, null);
+        this(database, precision, gzipThreshold, noSync, null, null, null);
     }
 
     /**
@@ -184,7 +191,7 @@ public final class WriteOptions {
                         @Nullable final Integer gzipThreshold,
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers) {
-        this(database, precision, gzipThreshold, null, defaultTags, headers);
+        this(database, precision, gzipThreshold, null, null, defaultTags, headers, null);
     }
 
     /**
@@ -209,7 +216,45 @@ public final class WriteOptions {
                         @Nullable final Boolean noSync,
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers) {
-        this(database, precision, gzipThreshold, noSync, defaultTags, headers, null);
+        this(database, precision, gzipThreshold, noSync, null, defaultTags, headers, null);
+    }
+
+    /**
+     * Construct WriteAPI options.
+     *
+     * @param database      The database to be used for InfluxDB operations.
+     *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
+     * @param precision     The precision to use for the timestamp of points.
+     *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     * @param gzipThreshold The threshold for compressing request body.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
+     * @param noSync        Skip waiting for WAL persistence on write.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_NO_SYNC}.
+     * @param acceptPartial Request partial write acceptance.
+     *                      If it is not specified then use {@link WriteOptions#DEFAULT_ACCEPT_PARTIAL}.
+     * @param defaultTags   Default tags to be added when writing points.
+     * @param headers       The headers to be added to write request.
+     *                      The headers specified here are preferred over the headers
+     *                      specified in the client configuration.
+     * @param tagOrder      Preferred order of tags in line protocol serialization.
+     *                      Null or empty tag names are ignored.
+     */
+    public WriteOptions(@Nullable final String database,
+                        @Nullable final WritePrecision precision,
+                        @Nullable final Integer gzipThreshold,
+                        @Nullable final Boolean noSync,
+                        @Nullable final Boolean acceptPartial,
+                        @Nullable final Map<String, String> defaultTags,
+                        @Nullable final Map<String, String> headers,
+                        @Nullable final List<String> tagOrder) {
+        this.database = database;
+        this.precision = precision;
+        this.gzipThreshold = gzipThreshold;
+        this.noSync = noSync;
+        this.acceptPartial = acceptPartial;
+        this.defaultTags = defaultTags == null ? Map.of() : defaultTags;
+        this.tagOrder = sanitizeTagOrder(tagOrder);
+        this.headers = headers == null ? Map.of() : headers;
     }
 
     /**
@@ -237,13 +282,7 @@ public final class WriteOptions {
                         @Nullable final Map<String, String> defaultTags,
                         @Nullable final Map<String, String> headers,
                         @Nullable final List<String> tagOrder) {
-        this.database = database;
-        this.precision = precision;
-        this.gzipThreshold = gzipThreshold;
-        this.noSync = noSync;
-        this.defaultTags = defaultTags == null ? Map.of() : defaultTags;
-        this.tagOrder = sanitizeTagOrder(tagOrder);
-        this.headers = headers == null ? Map.of() : headers;
+        this(database, precision, gzipThreshold, noSync, null, defaultTags, headers, tagOrder);
     }
 
     /**
@@ -304,6 +343,18 @@ public final class WriteOptions {
     }
 
     /**
+     * @param config with default value
+     * @return Accept partial write.
+     */
+    public boolean acceptPartialSafe(@Nonnull final ClientConfig config) {
+        Arguments.checkNotNull(config, "config");
+        return acceptPartial != null ? acceptPartial
+                : (config.getWriteAcceptPartial() != null
+                ? config.getWriteAcceptPartial()
+                : DEFAULT_ACCEPT_PARTIAL);
+    }
+
+    /**
      * @return The headers to be added to write request.
      */
     @Nonnull
@@ -332,6 +383,7 @@ public final class WriteOptions {
                 && precision == that.precision
                 && Objects.equals(gzipThreshold, that.gzipThreshold)
                 && Objects.equals(noSync, that.noSync)
+                && Objects.equals(acceptPartial, that.acceptPartial)
                 && defaultTags.equals(that.defaultTags)
                 && tagOrder.equals(that.tagOrder)
                 && headers.equals(that.headers);
@@ -339,7 +391,8 @@ public final class WriteOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(database, precision, gzipThreshold, noSync, defaultTags, tagOrder, headers);
+        return Objects.hash(database, precision, gzipThreshold, noSync, acceptPartial, defaultTags, tagOrder,
+                headers);
     }
 
     private boolean isNotDefined(final String option) {
@@ -368,6 +421,7 @@ public final class WriteOptions {
         private WritePrecision precision;
         private Integer gzipThreshold;
         private Boolean noSync;
+        private Boolean acceptPartial;
         private Map<String, String> defaultTags = new HashMap<>();
         private List<String> tagOrder = List.of();
         private Map<String, String> headers = new HashMap<>();
@@ -425,6 +479,19 @@ public final class WriteOptions {
         }
 
         /**
+         * Sets whether to request partial write acceptance.
+         *
+         * @param acceptPartial request partial write acceptance
+         * @return this
+         */
+        @Nonnull
+        public Builder acceptPartial(@Nonnull final Boolean acceptPartial) {
+
+            this.acceptPartial = acceptPartial;
+            return this;
+        }
+
+        /**
          * Sets defaultTags.
          *
          * @param defaultTags to be used when writing points
@@ -473,7 +540,7 @@ public final class WriteOptions {
     }
 
     private WriteOptions(@Nonnull final Builder builder) {
-        this(builder.database, builder.precision, builder.gzipThreshold, builder.noSync, builder.defaultTags,
-                builder.headers, builder.tagOrder);
+        this(builder.database, builder.precision, builder.gzipThreshold, builder.noSync, builder.acceptPartial,
+                builder.defaultTags, builder.headers, builder.tagOrder);
     }
 }

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -27,7 +27,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import mockwebserver3.RecordedRequest;
@@ -36,6 +39,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.influxdb.v3.client.config.ClientConfig;
 import com.influxdb.v3.client.write.WriteOptions;
@@ -106,7 +112,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("my-database");
+        assertThat(request.getUrl().queryParameter("db")).isEqualTo("my-database");
     }
 
     @Test
@@ -119,7 +125,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("my-database-2");
+        assertThat(request.getUrl().queryParameter("db")).isEqualTo("my-database-2");
     }
 
     @Test
@@ -147,7 +153,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("ns");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("nanosecond");
     }
 
     @Test
@@ -160,7 +166,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("s");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("second");
     }
 
     @Test
@@ -191,63 +197,64 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         assertThat(request.getHeaders().get("Content-Encoding")).isEqualTo("gzip");
     }
 
-    @Test
-    void writeNoSyncFalseUsesV2API() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("writeRoutingCases")
+    void writeRoutingCase(final String name,
+                          final Consumer<WriteOptions.Builder> configure,
+                          final String expectedPath,
+                          final String expectedDbParamName,
+                          final String expectedPrecision,
+                          @Nullable final String expectedNoSync,
+                          @Nullable final String expectedAcceptPartial) throws InterruptedException {
         mockServer.enqueue(createResponse(200));
 
+        WriteOptions.Builder optionsBuilder = new WriteOptions.Builder().precision(WritePrecision.NS);
+        configure.accept(optionsBuilder);
         client.writeRecord("mem,tag=one value=1.0",
-                new WriteOptions.Builder().precision(WritePrecision.NS).noSync(false).build());
+                optionsBuilder.build());
 
         assertThat(mockServer.getRequestCount()).isEqualTo(1);
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v2/write");
-        assertThat(request.getUrl().queryParameter("no_sync")).isNull();
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("ns");
-
+        assertThat(request.getUrl().encodedPath()).isEqualTo(expectedPath);
+        assertThat(request.getUrl().queryParameter(expectedDbParamName)).isEqualTo("my-database");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo(expectedPrecision);
+        assertThat(request.getUrl().queryParameter("no_sync")).isEqualTo(expectedNoSync);
+        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo(expectedAcceptPartial);
     }
 
-    @Test
-    void writeNoSyncTrueUsesV3API() throws InterruptedException {
-        mockServer.enqueue(createResponse(200));
-
-        client.writeRecord("mem,tag=one value=1.0",
-                new WriteOptions.Builder().precision(WritePrecision.NS).noSync(true).build());
-
-        assertThat(mockServer.getRequestCount()).isEqualTo(1);
-        RecordedRequest request = mockServer.takeRequest();
-        assertThat(request).isNotNull();
-        assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
-        assertThat(request.getUrl().queryParameter("no_sync")).isEqualTo("true");
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("nanosecond");
+    private static Stream<Arguments> writeRoutingCases() {
+        return Stream.of(
+                Arguments.of("v3 noSync=false", (Consumer<WriteOptions.Builder>) b -> b.noSync(false),
+                        "/api/v3/write_lp", "db", "nanosecond", null, null),
+                Arguments.of("v3 noSync=true", (Consumer<WriteOptions.Builder>) b -> b.noSync(true),
+                        "/api/v3/write_lp", "db", "nanosecond", "true", null),
+                Arguments.of("v3 acceptPartial=true", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true),
+                        "/api/v3/write_lp", "db", "nanosecond", null, null),
+                Arguments.of("v3 acceptPartial=false", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(false),
+                        "/api/v3/write_lp", "db", "nanosecond", null, "false"),
+                Arguments.of("v2 useV2Api=true", (Consumer<WriteOptions.Builder>) b -> b.useV2Api(true),
+                        "/api/v2/write", "bucket", "ns", null, null),
+                Arguments.of("v2 useV2Api=true, acceptPartial=false",
+                        (Consumer<WriteOptions.Builder>) b -> b.useV2Api(true).acceptPartial(false),
+                        "/api/v2/write", "bucket", "ns", null, null)
+        );
     }
 
-    @Test
-    void writeAcceptPartialTrueUsesV3API() throws InterruptedException {
-        mockServer.enqueue(createResponse(200));
-
-        client.writeRecord("mem,tag=one value=1.0",
-                new WriteOptions.Builder().precision(WritePrecision.NS).acceptPartial(true).build());
-
-        assertThat(mockServer.getRequestCount()).isEqualTo(1);
-        RecordedRequest request = mockServer.takeRequest();
-        assertThat(request).isNotNull();
-        assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
-        assertThat(request.getUrl().queryParameter("no_sync")).isNull();
-        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo("true");
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("nanosecond");
-    }
-
-    @Test
-    void writeNoSyncTrueOnV2ServerThrowsException() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("writeV3MethodNotAllowedCases")
+    void writeV3MethodNotAllowedMappedError(final String name,
+                                            final Consumer<WriteOptions.Builder> configure,
+                                            @Nullable final String expectedNoSync,
+                                            @Nullable final String expectedAcceptPartial) throws InterruptedException {
         mockServer.enqueue(createEmptyResponse(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
 
+        WriteOptions.Builder optionsBuilder = new WriteOptions.Builder().precision(WritePrecision.MS);
+        configure.accept(optionsBuilder);
+
         InfluxDBApiHttpException ae = org.junit.jupiter.api.Assertions.assertThrows(InfluxDBApiHttpException.class,
-                () -> client.writeRecord("mem,tag=one value=1.0",
-                        new WriteOptions.Builder().precision(WritePrecision.MS).noSync(true).build())
+                () -> client.writeRecord("mem,tag=one value=1.0", optionsBuilder.build())
         );
 
         assertThat(mockServer.getRequestCount()).isEqualTo(1);
@@ -255,34 +262,31 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
         assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
-        assertThat(request.getUrl().queryParameter("no_sync")).isEqualTo("true");
+        assertThat(request.getUrl().queryParameter("no_sync")).isEqualTo(expectedNoSync);
+        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo(expectedAcceptPartial);
         assertThat(request.getUrl().queryParameter("precision")).isEqualTo("millisecond");
 
         assertThat(ae.statusCode()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED.code());
-        assertThat(ae.getMessage()).contains("Server doesn't support write with NoSync=true or AcceptPartial=true"
-                + " (supported by InfluxDB 3 Core/Enterprise servers only).");
+        assertThat(ae.getMessage()).contains("Server doesn't support v3 write API. "
+                + "Use WriteOptions.Builder.useV2Api(true) for v2 compatibility endpoint.");
+    }
+
+    private static Stream<Arguments> writeV3MethodNotAllowedCases() {
+        return Stream.of(
+                Arguments.of("noSync=true", (Consumer<WriteOptions.Builder>) b -> b.noSync(true), "true", null),
+                Arguments.of("acceptPartial=true", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true), null, null)
+        );
     }
 
     @Test
-    void writeAcceptPartialTrueOnV2ServerThrowsException() throws InterruptedException {
-        mockServer.enqueue(createEmptyResponse(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
+    void writeUseV2ApiNoSyncValidation() {
+        Throwable thrown = catchThrowable(() -> client.writeRecord("mem,tag=one value=1.0",
+                new WriteOptions.Builder().useV2Api(true).noSync(true).build()));
 
-        InfluxDBApiHttpException ae = org.junit.jupiter.api.Assertions.assertThrows(InfluxDBApiHttpException.class,
-                () -> client.writeRecord("mem,tag=one value=1.0",
-                        new WriteOptions.Builder().precision(WritePrecision.MS).acceptPartial(true).build())
-        );
-
-        assertThat(mockServer.getRequestCount()).isEqualTo(1);
-        RecordedRequest request = mockServer.takeRequest();
-        assertThat(request).isNotNull();
-        assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
-        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo("true");
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("millisecond");
-
-        assertThat(ae.statusCode()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED.code());
-        assertThat(ae.getMessage()).contains("Server doesn't support write with NoSync=true or AcceptPartial=true"
-                + " (supported by InfluxDB 3 Core/Enterprise servers only).");
+        Assertions.assertThat(thrown)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid write options: NoSync cannot be used in V2 API");
+        assertThat(mockServer.getRequestCount()).isEqualTo(0);
     }
 
     @Test
@@ -295,7 +299,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
     }
 
     @Test
@@ -311,7 +315,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
     }
 
     @Test
@@ -325,7 +329,21 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", false, true, false);
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+    }
+
+    @Test
+    void writeRecordWithDefaultWriteOptionsUseV2Config() throws Exception {
+        mockServer.enqueue(createResponse(200));
+
+        ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
+                .writeUseV2Api(true)
+                .build();
+        try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
+            client.writeRecord("mem,tag=one value=1.0");
+        }
+
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -338,7 +356,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecords(List.of("mem,tag=one value=1.0"));
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
     }
 
     @Test
@@ -354,7 +372,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecords(List.of("mem,tag=one value=1.0"));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
     }
 
     @Test
@@ -370,7 +388,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
     }
 
     @Test
@@ -389,7 +407,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
     }
 
     @Test
@@ -405,7 +423,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
     }
 
     @Test
@@ -424,34 +442,26 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
     }
 
     private void checkWriteCalled(final String expectedPath, final String expectedDB,
-                                  final String expectedPrecision, final boolean expectedNoSync,
-                                  final boolean expectedAcceptPartial,
+                                  final String expectedPrecision, final boolean expectedV3,
+                                  @Nullable final String expectedNoSync,
+                                  @Nullable final String expectedAcceptPartial,
                                   final boolean expectedGzip) throws InterruptedException {
         RecordedRequest request = assertThatServerRequested();
         HttpUrl requestUrl = request.getUrl();
         assertThat(requestUrl).isNotNull();
         assertThat(requestUrl.encodedPath()).isEqualTo(expectedPath);
-        boolean expectedV3 = expectedNoSync || expectedAcceptPartial;
         if (expectedV3) {
             assertThat(requestUrl.queryParameter("db")).isEqualTo(expectedDB);
         } else {
             assertThat(requestUrl.queryParameter("bucket")).isEqualTo(expectedDB);
         }
         assertThat(requestUrl.queryParameter("precision")).isEqualTo(expectedPrecision);
-        if (expectedNoSync) {
-            assertThat(requestUrl.queryParameter("no_sync")).isEqualTo("true");
-        } else {
-            assertThat(requestUrl.queryParameter("no_sync")).isNull();
-        }
-        if (expectedAcceptPartial) {
-            assertThat(requestUrl.queryParameter("accept_partial")).isEqualTo("true");
-        } else {
-            assertThat(requestUrl.queryParameter("accept_partial")).isNull();
-        }
+        assertThat(requestUrl.queryParameter("no_sync")).isEqualTo(expectedNoSync);
+        assertThat(requestUrl.queryParameter("accept_partial")).isEqualTo(expectedAcceptPartial);
         if (expectedGzip) {
             assertThat(request.getHeaders().get("Content-Encoding")).isEqualTo("gzip");
         } else {
@@ -480,8 +490,8 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         assertThat(request.getUrl()).isNotNull();
         assertThat(request.getHeaders().get("Content-Type")).isEqualTo("text/plain; charset=utf-8");
         assertThat(request.getHeaders().get("Content-Encoding")).isEqualTo("gzip");
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("s");
-        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("your-database");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("second");
+        assertThat(request.getUrl().queryParameter("db")).isEqualTo("your-database");
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -274,7 +274,12 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     private static Stream<Arguments> writeV3MethodNotAllowedCases() {
         return Stream.of(
                 Arguments.of("noSync=true", (Consumer<WriteOptions.Builder>) b -> b.noSync(true), "true", null),
-                Arguments.of("acceptPartial=true", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true), null, null)
+                Arguments.of(
+                        "acceptPartial=true",
+                        (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true),
+                        null,
+                        null
+                )
         );
     }
 

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -225,6 +225,23 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     }
 
     @Test
+    void writeAcceptPartialTrueUsesV3API() throws InterruptedException {
+        mockServer.enqueue(createResponse(200));
+
+        client.writeRecord("mem,tag=one value=1.0",
+                new WriteOptions.Builder().precision(WritePrecision.NS).acceptPartial(true).build());
+
+        assertThat(mockServer.getRequestCount()).isEqualTo(1);
+        RecordedRequest request = mockServer.takeRequest();
+        assertThat(request).isNotNull();
+        assertThat(request.getUrl()).isNotNull();
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
+        assertThat(request.getUrl().queryParameter("no_sync")).isNull();
+        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo("true");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("nanosecond");
+    }
+
+    @Test
     void writeNoSyncTrueOnV2ServerThrowsException() throws InterruptedException {
         mockServer.enqueue(createEmptyResponse(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
 
@@ -242,7 +259,29 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         assertThat(request.getUrl().queryParameter("precision")).isEqualTo("millisecond");
 
         assertThat(ae.statusCode()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED.code());
-        assertThat(ae.getMessage()).contains("Server doesn't support write with NoSync=true"
+        assertThat(ae.getMessage()).contains("Server doesn't support write with NoSync=true or AcceptPartial=true"
+                + " (supported by InfluxDB 3 Core/Enterprise servers only).");
+    }
+
+    @Test
+    void writeAcceptPartialTrueOnV2ServerThrowsException() throws InterruptedException {
+        mockServer.enqueue(createEmptyResponse(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
+
+        InfluxDBApiHttpException ae = org.junit.jupiter.api.Assertions.assertThrows(InfluxDBApiHttpException.class,
+                () -> client.writeRecord("mem,tag=one value=1.0",
+                        new WriteOptions.Builder().precision(WritePrecision.MS).acceptPartial(true).build())
+        );
+
+        assertThat(mockServer.getRequestCount()).isEqualTo(1);
+        RecordedRequest request = mockServer.takeRequest();
+        assertThat(request).isNotNull();
+        assertThat(request.getUrl()).isNotNull();
+        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
+        assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo("true");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("millisecond");
+
+        assertThat(ae.statusCode()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED.code());
+        assertThat(ae.getMessage()).contains("Server doesn't support write with NoSync=true or AcceptPartial=true"
                 + " (supported by InfluxDB 3 Core/Enterprise servers only).");
     }
 
@@ -256,7 +295,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
     }
 
     @Test
@@ -272,7 +311,21 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
+    }
+
+    @Test
+    void writeRecordWithDefaultWriteOptionsAcceptPartialConfig() throws Exception {
+        mockServer.enqueue(createResponse(200));
+
+        ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
+                .writeAcceptPartial(true)
+                .build();
+        try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
+            client.writeRecord("mem,tag=one value=1.0");
+        }
+
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", false, true, false);
     }
 
     @Test
@@ -285,7 +338,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecords(List.of("mem,tag=one value=1.0"));
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
     }
 
     @Test
@@ -301,7 +354,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecords(List.of("mem,tag=one value=1.0"));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
     }
 
     @Test
@@ -317,7 +370,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
     }
 
     @Test
@@ -336,7 +389,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
     }
 
     @Test
@@ -352,7 +405,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v2/write", "DB", "ns", false, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, false, false);
     }
 
     @Test
@@ -371,17 +424,19 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, true);
+        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, false, true);
     }
 
     private void checkWriteCalled(final String expectedPath, final String expectedDB,
                                   final String expectedPrecision, final boolean expectedNoSync,
+                                  final boolean expectedAcceptPartial,
                                   final boolean expectedGzip) throws InterruptedException {
         RecordedRequest request = assertThatServerRequested();
         HttpUrl requestUrl = request.getUrl();
         assertThat(requestUrl).isNotNull();
         assertThat(requestUrl.encodedPath()).isEqualTo(expectedPath);
-        if (expectedNoSync) {
+        boolean expectedV3 = expectedNoSync || expectedAcceptPartial;
+        if (expectedV3) {
             assertThat(requestUrl.queryParameter("db")).isEqualTo(expectedDB);
         } else {
             assertThat(requestUrl.queryParameter("bucket")).isEqualTo(expectedDB);
@@ -391,6 +446,11 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             assertThat(requestUrl.queryParameter("no_sync")).isEqualTo("true");
         } else {
             assertThat(requestUrl.queryParameter("no_sync")).isNull();
+        }
+        if (expectedAcceptPartial) {
+            assertThat(requestUrl.queryParameter("accept_partial")).isEqualTo("true");
+        } else {
+            assertThat(requestUrl.queryParameter("accept_partial")).isNull();
         }
         if (expectedGzip) {
             assertThat(request.getHeaders().get("Content-Encoding")).isEqualTo("gzip");

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -62,7 +62,7 @@ class ClientConfigTest {
                 .organization("my-org")
                 .database("my-db")
                 .writePrecision(WritePrecision.NS)
-                .writeAcceptPartial(true)
+                .writeAcceptPartial(false)
                 .timeout(Duration.ofSeconds(30))
                 .writeTimeout(Duration.ofSeconds(35))
                 .queryTimeout(Duration.ofSeconds(120))
@@ -94,7 +94,8 @@ class ClientConfigTest {
         Assertions.assertThat(configString.contains("database='my-db'")).isEqualTo(true);
         Assertions.assertThat(configString.contains("gzipThreshold=1000")).isEqualTo(true);
         Assertions.assertThat(configString).contains("writeNoSync=false");
-        Assertions.assertThat(configString).contains("writeAcceptPartial=false");
+        Assertions.assertThat(configString).contains("writeAcceptPartial=true");
+        Assertions.assertThat(configString).contains("writeUseV2Api=false");
         Assertions.assertThat(configString).contains("timeout=PT30S");
         Assertions.assertThat(configString).contains("writeTimeout=PT35S");
         Assertions.assertThat(configString).contains("queryTimeout=PT2M");
@@ -107,7 +108,7 @@ class ClientConfigTest {
         ClientConfig cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
                         + "?token=my-token&org=my-org&database=my-db&gzipThreshold=128"
-                        + "&writeNoSync=true&writeAcceptPartial=true");
+                        + "&writeNoSync=true&writeAcceptPartial=true&writeUseV2Api=true");
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
         Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");
@@ -116,6 +117,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(128);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
         Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(true);
 
         cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
@@ -128,6 +130,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(WriteOptions.DEFAULT_NO_SYNC);
         Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(WriteOptions.DEFAULT_USE_V2_API);
 
         cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
@@ -139,6 +142,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(WriteOptions.DEFAULT_NO_SYNC);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(WriteOptions.DEFAULT_USE_V2_API);
 
         cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
@@ -228,6 +232,7 @@ class ClientConfigTest {
                 "INFLUX_GZIP_THRESHOLD", "64",
                 "INFLUX_WRITE_NO_SYNC", "true",
                 "INFLUX_WRITE_ACCEPT_PARTIAL", "true",
+                "INFLUX_WRITE_USE_V2_API", "true",
                 "INFLUX_DISABLE_GRPC_COMPRESSION", "true"
 
         );
@@ -241,6 +246,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
         Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(true);
         Assertions.assertThat(cfg.getDisableGRPCCompression()).isTrue();
     }
 
@@ -309,6 +315,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(WriteOptions.DEFAULT_NO_SYNC);
         Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(WriteOptions.DEFAULT_USE_V2_API);
 
         // basic
         properties = new Properties();
@@ -347,6 +354,7 @@ class ClientConfigTest {
         properties.put("influx.gzipThreshold", "64");
         properties.put("influx.writeNoSync", "true");
         properties.put("influx.writeAcceptPartial", "true");
+        properties.put("influx.writeUseV2Api", "true");
         properties.put("influx.disableGRPCCompression", "true");
         cfg = new ClientConfig.Builder()
                 .build(new HashMap<>(), properties);
@@ -358,6 +366,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
         Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteUseV2Api()).isEqualTo(true);
         Assertions.assertThat(cfg.getDisableGRPCCompression()).isTrue();
     }
 

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -79,6 +79,7 @@ class ClientConfigTest {
         Assertions.assertThat(configString.contains("database='my-db'")).isEqualTo(true);
         Assertions.assertThat(configString.contains("gzipThreshold=1000")).isEqualTo(true);
         Assertions.assertThat(configString).contains("writeNoSync=false");
+        Assertions.assertThat(configString).contains("writeAcceptPartial=false");
         Assertions.assertThat(configString).contains("timeout=PT30S");
         Assertions.assertThat(configString).contains("writeTimeout=PT35S");
         Assertions.assertThat(configString).contains("queryTimeout=PT2M");
@@ -90,7 +91,8 @@ class ClientConfigTest {
     void fromConnectionString() throws MalformedURLException {
         ClientConfig cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
-                        + "?token=my-token&org=my-org&database=my-db&gzipThreshold=128&writeNoSync=true");
+                        + "?token=my-token&org=my-org&database=my-db&gzipThreshold=128"
+                        + "&writeNoSync=true&writeAcceptPartial=true");
         Assertions.assertThat(cfg.getHost()).isEqualTo("http://localhost:9999/");
         Assertions.assertThat(cfg.getToken()).isEqualTo("my-token".toCharArray());
         Assertions.assertThat(cfg.getOrganization()).isEqualTo("my-org");
@@ -98,6 +100,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS); // default
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(128);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
 
         cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
@@ -109,6 +112,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.US);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000); // default
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(WriteOptions.DEFAULT_NO_SYNC);
+        Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
 
         cfg = new ClientConfig.Builder()
                 .build("http://localhost:9999/"
@@ -208,6 +212,7 @@ class ClientConfigTest {
                 "INFLUX_PRECISION", "ms",
                 "INFLUX_GZIP_THRESHOLD", "64",
                 "INFLUX_WRITE_NO_SYNC", "true",
+                "INFLUX_WRITE_ACCEPT_PARTIAL", "true",
                 "INFLUX_DISABLE_GRPC_COMPRESSION", "true"
 
         );
@@ -220,6 +225,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
         Assertions.assertThat(cfg.getDisableGRPCCompression()).isTrue();
     }
 
@@ -287,6 +293,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.NS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(1000);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(WriteOptions.DEFAULT_NO_SYNC);
+        Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
 
         // basic
         properties = new Properties();
@@ -324,6 +331,7 @@ class ClientConfigTest {
         properties.put("influx.precision", "ms");
         properties.put("influx.gzipThreshold", "64");
         properties.put("influx.writeNoSync", "true");
+        properties.put("influx.writeAcceptPartial", "true");
         properties.put("influx.disableGRPCCompression", "true");
         cfg = new ClientConfig.Builder()
                 .build(new HashMap<>(), properties);
@@ -334,6 +342,7 @@ class ClientConfigTest {
         Assertions.assertThat(cfg.getWritePrecision()).isEqualTo(WritePrecision.MS);
         Assertions.assertThat(cfg.getGzipThreshold()).isEqualTo(64);
         Assertions.assertThat(cfg.getWriteNoSync()).isEqualTo(true);
+        Assertions.assertThat(cfg.getWriteAcceptPartial()).isEqualTo(true);
         Assertions.assertThat(cfg.getDisableGRPCCompression()).isTrue();
     }
 

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -56,6 +56,21 @@ class ClientConfigTest {
         Assertions.assertThat(config).isEqualTo(config);
         Assertions.assertThat(config).isEqualTo(configBuilder.build());
         Assertions.assertThat(config).isNotEqualTo(configBuilder);
+        Assertions.assertThat(config).isNotEqualTo(new ClientConfig.Builder()
+                .host("http://localhost:9999")
+                .token("my-token".toCharArray())
+                .organization("my-org")
+                .database("my-db")
+                .writePrecision(WritePrecision.NS)
+                .writeAcceptPartial(true)
+                .timeout(Duration.ofSeconds(30))
+                .writeTimeout(Duration.ofSeconds(35))
+                .queryTimeout(Duration.ofSeconds(120))
+                .allowHttpRedirects(true)
+                .disableServerCertificateValidation(true)
+                .headers(Map.of("X-device", "ab-01"))
+                .disableGRPCCompression(true)
+                .build());
         Assertions.assertThat(config).isNotEqualTo(configBuilder.database("database").build());
     }
 

--- a/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
+++ b/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
@@ -253,10 +253,40 @@ public class E2ETest {
                     + "temperature,room=room3 value=24.064857\n"
                     + "temperature,room=room4 value=43i";
 
-            Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points));
+            WriteOptions options = new WriteOptions.Builder()
+                    .acceptPartial(false)
+                    .build();
+            Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points, options));
+            Assertions.assertThat(thrown).isInstanceOf(InfluxDBPartialWriteException.class);
             Assertions.assertThat(thrown.getMessage())
-                    .isEqualTo("HTTP status code: 400; Message: write buffer error: "
-                            + "line protocol parse failed: Expected at least one space character, got end of input");
+                    .startsWith("HTTP status code: 400; Message: parsing failed for write_lp endpoint");
+        }
+    }
+
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_URL", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_TOKEN", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_DATABASE", matches = ".*")
+    @Test
+    public void testWriteErrorWithUseV2Api() throws Exception {
+        try (InfluxDBClient client = InfluxDBClient.getInstance(
+                System.getenv("TESTING_INFLUXDB_URL"),
+                System.getenv("TESTING_INFLUXDB_TOKEN").toCharArray(),
+                System.getenv("TESTING_INFLUXDB_DATABASE"),
+                null)) {
+
+            String points = "temperature,room=room1 value=18.94647\n"
+                    + "temperatureroom=room2value=20.268019\n"
+                    + "temperature,room=room3 value=24.064857\n"
+                    + "temperature,room=room4 value=43i";
+
+            WriteOptions options = new WriteOptions.Builder()
+                    .useV2Api(true)
+                    .build();
+            Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points, options));
+            Assertions.assertThat(thrown).isInstanceOf(InfluxDBApiHttpException.class);
+            Assertions.assertThat(thrown).isNotInstanceOf(InfluxDBPartialWriteException.class);
+            Assertions.assertThat(thrown.getMessage())
+                    .contains("write buffer error: line protocol parse failed");
         }
     }
 

--- a/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
+++ b/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
@@ -199,10 +199,9 @@ public class E2ETest {
                 System.getenv("TESTING_INFLUXDB_DATABASE"),
                 null)) {
 
-            String points = "temperature,room=room1 value=18.94647\n"
-                    + "temperatureroom=room2value=20.268019\n"
-                    + "temperature,room=room3 value=24.064857\n"
-                    + "temperature,room=room4 value=43i";
+            String points = "home,room=Sunroom temp=96 1735545600\n"
+                    + "home,room=Sunroom temp=\"hi\" 1735545610\n"
+                    + "home,room=Sunroom temp=88i 1735545620";
 
             WriteOptions options = new WriteOptions.Builder()
                     .acceptPartial(true)
@@ -212,25 +211,27 @@ public class E2ETest {
             Assertions.assertThat(thrown).isInstanceOf(InfluxDBPartialWriteException.class);
 
             String expectedMessage = "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-                    + "\tline 2: Expected at least one space character, got end of input (temperatureroom=room)\n"
-                    + "\tline 4: invalid column type for column 'value', expected iox::column_type::field::float, "
-                    + "got iox::column_type::field::integer (temperature,room=roo)";
+                    + "\tline 2: invalid column type for column 'temp', expected iox::column_type::field::float, "
+                    + "got iox::column_type::field::string (home,room=Sunroom te)\n"
+                    + "\tline 3: invalid column type for column 'temp', expected iox::column_type::field::float, "
+                    + "got iox::column_type::field::integer (home,room=Sunroom te)";
             Assertions.assertThat(thrown.getMessage()).isEqualTo(expectedMessage);
 
             InfluxDBPartialWriteException partialError = (InfluxDBPartialWriteException) thrown;
             Assertions.assertThat(partialError.lineErrors()).hasSize(2);
             Assertions.assertThat(partialError.lineErrors().get(0).lineNumber()).isEqualTo(2);
             Assertions.assertThat(partialError.lineErrors().get(0).errorMessage())
-                    .isEqualTo("Expected at least one space character, got end of input");
+                    .isEqualTo("invalid column type for column 'temp', expected iox::column_type::field::float, "
+                            + "got iox::column_type::field::string");
             Assertions.assertThat(partialError.lineErrors().get(0).originalLine())
-                    .isEqualTo("temperatureroom=room");
+                    .isEqualTo("home,room=Sunroom te");
 
-            Assertions.assertThat(partialError.lineErrors().get(1).lineNumber()).isEqualTo(4);
+            Assertions.assertThat(partialError.lineErrors().get(1).lineNumber()).isEqualTo(3);
             Assertions.assertThat(partialError.lineErrors().get(1).errorMessage())
-                    .isEqualTo("invalid column type for column 'value', expected iox::column_type::field::float, "
+                    .isEqualTo("invalid column type for column 'temp', expected iox::column_type::field::float, "
                             + "got iox::column_type::field::integer");
             Assertions.assertThat(partialError.lineErrors().get(1).originalLine())
-                    .isEqualTo("temperature,room=roo");
+                    .isEqualTo("home,room=Sunroom te");
 
             Assertions.assertThat(partialError).isInstanceOf(InfluxDBApiHttpException.class);
             Assertions.assertThat(partialError.statusCode()).isEqualTo(400);
@@ -248,10 +249,9 @@ public class E2ETest {
                 System.getenv("TESTING_INFLUXDB_DATABASE"),
                 null)) {
 
-            String points = "temperature,room=room1 value=18.94647\n"
-                    + "temperatureroom=room2value=20.268019\n"
-                    + "temperature,room=room3 value=24.064857\n"
-                    + "temperature,room=room4 value=43i";
+            String points = "home,room=Sunroom temp=96 1735545600\n"
+                    + "home,room=Sunroom temp=\"hi\" 1735545610\n"
+                    + "home,room=Sunroom temp=88i 1735545620";
 
             WriteOptions options = new WriteOptions.Builder()
                     .acceptPartial(false)
@@ -259,7 +259,16 @@ public class E2ETest {
             Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points, options));
             Assertions.assertThat(thrown).isInstanceOf(InfluxDBPartialWriteException.class);
             Assertions.assertThat(thrown.getMessage())
-                    .startsWith("HTTP status code: 400; Message: parsing failed for write_lp endpoint");
+                    .contains("parsing failed for write_lp endpoint");
+
+            InfluxDBPartialWriteException partialError = (InfluxDBPartialWriteException) thrown;
+            Assertions.assertThat(partialError.lineErrors()).hasSize(1);
+            Assertions.assertThat(partialError.lineErrors().get(0).lineNumber()).isEqualTo(2);
+            Assertions.assertThat(partialError.lineErrors().get(0).errorMessage())
+                    .isEqualTo("invalid column type for column 'temp', expected iox::column_type::field::float, "
+                            + "got iox::column_type::field::string");
+            Assertions.assertThat(partialError.lineErrors().get(0).originalLine())
+                    .isEqualTo("home,room=Sunroom te");
         }
     }
 
@@ -274,10 +283,9 @@ public class E2ETest {
                 System.getenv("TESTING_INFLUXDB_DATABASE"),
                 null)) {
 
-            String points = "temperature,room=room1 value=18.94647\n"
-                    + "temperatureroom=room2value=20.268019\n"
-                    + "temperature,room=room3 value=24.064857\n"
-                    + "temperature,room=room4 value=43i";
+            String points = "home,room=Sunroom temp=96 1735545600\n"
+                    + "home,room=Sunroom temp=\"hi\" 1735545610\n"
+                    + "home,room=Sunroom temp=88i 1735545620";
 
             WriteOptions options = new WriteOptions.Builder()
                     .useV2Api(true)

--- a/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
+++ b/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
@@ -41,7 +41,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import com.influxdb.v3.client.InfluxDBApiHttpException;
 import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.InfluxDBPartialWriteException;
 import com.influxdb.v3.client.Point;
 import com.influxdb.v3.client.PointValues;
 import com.influxdb.v3.client.config.ClientConfig;
@@ -183,6 +185,78 @@ public class E2ETest {
                             Assertions.assertThat(objects[7]).isEqualTo(BigInteger.valueOf(timestamp * 1_000_000_000));
                         });
             }
+        }
+    }
+
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_URL", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_TOKEN", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_DATABASE", matches = ".*")
+    @Test
+    public void testAcceptPartialWriteError() throws Exception {
+        try (InfluxDBClient client = InfluxDBClient.getInstance(
+                System.getenv("TESTING_INFLUXDB_URL"),
+                System.getenv("TESTING_INFLUXDB_TOKEN").toCharArray(),
+                System.getenv("TESTING_INFLUXDB_DATABASE"),
+                null)) {
+
+            String points = "temperature,room=room1 value=18.94647\n"
+                    + "temperatureroom=room2value=20.268019\n"
+                    + "temperature,room=room3 value=24.064857\n"
+                    + "temperature,room=room4 value=43i";
+
+            WriteOptions options = new WriteOptions.Builder()
+                    .acceptPartial(true)
+                    .build();
+
+            Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points, options));
+            Assertions.assertThat(thrown).isInstanceOf(InfluxDBPartialWriteException.class);
+
+            String expectedMessage = "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+                    + "\tline 2: Expected at least one space character, got end of input (temperatureroom=room)\n"
+                    + "\tline 4: invalid column type for column 'value', expected iox::column_type::field::float, "
+                    + "got iox::column_type::field::integer (temperature,room=roo)";
+            Assertions.assertThat(thrown.getMessage()).isEqualTo(expectedMessage);
+
+            InfluxDBPartialWriteException partialError = (InfluxDBPartialWriteException) thrown;
+            Assertions.assertThat(partialError.lineErrors()).hasSize(2);
+            Assertions.assertThat(partialError.lineErrors().get(0).lineNumber()).isEqualTo(2);
+            Assertions.assertThat(partialError.lineErrors().get(0).errorMessage())
+                    .isEqualTo("Expected at least one space character, got end of input");
+            Assertions.assertThat(partialError.lineErrors().get(0).originalLine())
+                    .isEqualTo("temperatureroom=room");
+
+            Assertions.assertThat(partialError.lineErrors().get(1).lineNumber()).isEqualTo(4);
+            Assertions.assertThat(partialError.lineErrors().get(1).errorMessage())
+                    .isEqualTo("invalid column type for column 'value', expected iox::column_type::field::float, "
+                            + "got iox::column_type::field::integer");
+            Assertions.assertThat(partialError.lineErrors().get(1).originalLine())
+                    .isEqualTo("temperature,room=roo");
+
+            Assertions.assertThat(partialError).isInstanceOf(InfluxDBApiHttpException.class);
+            Assertions.assertThat(partialError.statusCode()).isEqualTo(400);
+        }
+    }
+
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_URL", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_TOKEN", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_DATABASE", matches = ".*")
+    @Test
+    public void testWriteErrorWithoutAcceptPartial() throws Exception {
+        try (InfluxDBClient client = InfluxDBClient.getInstance(
+                System.getenv("TESTING_INFLUXDB_URL"),
+                System.getenv("TESTING_INFLUXDB_TOKEN").toCharArray(),
+                System.getenv("TESTING_INFLUXDB_DATABASE"),
+                null)) {
+
+            String points = "temperature,room=room1 value=18.94647\n"
+                    + "temperatureroom=room2value=20.268019\n"
+                    + "temperature,room=room3 value=24.064857\n"
+                    + "temperature,room=room4 value=43i";
+
+            Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points));
+            Assertions.assertThat(thrown.getMessage())
+                    .isEqualTo("HTTP status code: 400; Message: write buffer error: "
+                            + "line protocol parse failed: Expected at least one space character, got end of input");
         }
     }
 

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -547,11 +547,19 @@ public class RestClientTest extends AbstractMockServerTest {
               .host(baseURL)
               .build());
 
-      Assertions.assertThatThrownBy(
-            () -> restClient.request("ping", HttpMethod.GET, null, null, null)
-        )
-              .isInstanceOf(InfluxDBApiException.class)
+      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Assertions.assertThat(thrown)
+              .isInstanceOf(InfluxDBPartialWriteException.class)
+              .isInstanceOf(InfluxDBApiHttpException.class)
               .hasMessage("HTTP status code: 400; Message: invalid field value");
+
+      InfluxDBPartialWriteException partialWriteException = (InfluxDBPartialWriteException) thrown;
+      Assertions.assertThat(partialWriteException.statusCode()).isEqualTo(400);
+      Assertions.assertThat(partialWriteException.lineErrors()).hasSize(1);
+      InfluxDBPartialWriteException.LineError lineError = partialWriteException.lineErrors().get(0);
+      Assertions.assertThat(lineError.lineNumber()).isNull();
+      Assertions.assertThat(lineError.errorMessage()).isEqualTo("invalid field value");
+      Assertions.assertThat(lineError.originalLine()).isNull();
     }
 
     @Test
@@ -669,6 +677,7 @@ public class RestClientTest extends AbstractMockServerTest {
     @MethodSource("errorFromBodyV3FallbackCases")
     public void errorFromBodyV3FallbackCase(final String testName,
                                             final String body,
+                                            final Class<? extends InfluxDBApiException> expectedClass,
                                             final String expectedMessage) {
 
       mockServer.enqueue(createResponse(400,
@@ -680,11 +689,10 @@ public class RestClientTest extends AbstractMockServerTest {
         .host(baseURL)
         .build());
 
-      Assertions.assertThatThrownBy(
-          () -> restClient.request("ping", HttpMethod.GET, null, null, null)
-        )
-        .isInstanceOf(InfluxDBApiException.class)
-        .hasMessage(expectedMessage);
+      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Assertions.assertThat(thrown)
+              .isInstanceOf(expectedClass)
+              .hasMessage(expectedMessage);
     }
 
     private static Stream<Arguments> errorFromBodyV3FallbackCases() {
@@ -692,6 +700,7 @@ public class RestClientTest extends AbstractMockServerTest {
         Arguments.of(
           "missing error with data array falls back to body",
           "{\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}]}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: "
             + "{\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}]}"
         ),
@@ -699,6 +708,7 @@ public class RestClientTest extends AbstractMockServerTest {
           "empty error with data array falls back to body",
           "{\"error\":\"\",\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":"
             + "\"bad lp\"}]}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: "
             + "{\"error\":\"\",\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":"
             + "\"bad lp\"}]}"
@@ -706,22 +716,38 @@ public class RestClientTest extends AbstractMockServerTest {
         Arguments.of(
           "data object without error_message falls back to error",
           "{\"error\":\"parsing failed\",\"data\":{}}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data object with empty error_message falls back to error",
           "{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"\"}}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data string falls back to error",
           "{\"error\":\"parsing failed\",\"data\":\"not-an-object\"}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data number falls back to error",
           "{\"error\":\"parsing failed\",\"data\":123}",
+          InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
+        ),
+        Arguments.of(
+          "partial-write with invalid data string falls back to error",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":\"invalid\"}",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: partial write of line protocol occurred"
+        ),
+        Arguments.of(
+          "partial-write with empty data object falls back to error",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":{}}",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: partial write of line protocol occurred"
         )
       );
     }

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -51,6 +51,7 @@ import com.influxdb.v3.client.AbstractMockServerTest;
 import com.influxdb.v3.client.InfluxDBApiException;
 import com.influxdb.v3.client.InfluxDBApiHttpException;
 import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.InfluxDBPartialWriteException;
 import com.influxdb.v3.client.config.ClientConfig;
 import com.influxdb.v3.client.write.WriteOptions;
 
@@ -567,13 +568,21 @@ public class RestClientTest extends AbstractMockServerTest {
         .host(baseURL)
         .build());
 
-      Assertions.assertThatThrownBy(
-          () -> restClient.request("ping", HttpMethod.GET, null, null, null)
-        )
-        .isInstanceOf(InfluxDBApiException.class)
-        .hasMessage("HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-          + "\tline 2: invalid column type for column 'v', expected iox::column_type::field::integer,"
-          + " got iox::column_type::field::float (testa6a3ad v=1 17702)");
+      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Assertions.assertThat(thrown)
+              .isInstanceOf(InfluxDBPartialWriteException.class)
+              .hasMessage("HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+                      + "\tline 2: invalid column type for column 'v', expected iox::column_type::field::integer,"
+                      + " got iox::column_type::field::float (testa6a3ad v=1 17702)");
+
+      InfluxDBPartialWriteException partialWriteException = (InfluxDBPartialWriteException) thrown;
+      Assertions.assertThat(partialWriteException.lineErrors()).hasSize(1);
+      InfluxDBPartialWriteException.LineError lineError = partialWriteException.lineErrors().get(0);
+      Assertions.assertThat(lineError.lineNumber()).isEqualTo(2);
+      Assertions.assertThat(lineError.errorMessage())
+              .isEqualTo("invalid column type for column 'v', expected iox::column_type::field::integer,"
+                      + " got iox::column_type::field::float");
+      Assertions.assertThat(lineError.originalLine()).isEqualTo("testa6a3ad v=1 17702");
     }
 
     @ParameterizedTest(name = "{0}")

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -547,7 +547,7 @@ public class RestClientTest extends AbstractMockServerTest {
               .host(baseURL)
               .build());
 
-      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Throwable thrown = catchThrowable(() -> restClient.request("api/v3/write_lp", HttpMethod.POST, null, null, null));
       Assertions.assertThat(thrown)
               .isInstanceOf(InfluxDBPartialWriteException.class)
               .isInstanceOf(InfluxDBApiHttpException.class)
@@ -576,7 +576,7 @@ public class RestClientTest extends AbstractMockServerTest {
         .host(baseURL)
         .build());
 
-      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Throwable thrown = catchThrowable(() -> restClient.request("api/v3/write_lp", HttpMethod.POST, null, null, null));
       Assertions.assertThat(thrown)
               .isInstanceOf(InfluxDBPartialWriteException.class)
               .hasMessage("HTTP status code: 400; Message: partial write of line protocol occurred:\n"
@@ -591,6 +591,28 @@ public class RestClientTest extends AbstractMockServerTest {
               .isEqualTo("invalid column type for column 'v', expected iox::column_type::field::integer,"
                       + " got iox::column_type::field::float");
       Assertions.assertThat(lineError.originalLine()).isEqualTo("testa6a3ad v=1 17702");
+    }
+
+    @Test
+    public void errorFromBodyV3WithDataArrayAnyInvalidItemFallsBackToHttpException() {
+      mockServer.enqueue(createResponse(400,
+        "application/json",
+        null,
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+          + "\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"},"
+          + "{\"error_message\":\"bad line 2\",\"line_number\":\"x\",\"original_line\":\"bad lp 2\"}]}"));
+
+      restClient = new RestClient(new ClientConfig.Builder()
+        .host(baseURL)
+        .build());
+
+      Throwable thrown = catchThrowable(() -> restClient.request("api/v3/write_lp", HttpMethod.POST, null, null, null));
+      Assertions.assertThat(thrown)
+        .isInstanceOf(InfluxDBApiHttpException.class)
+        .isNotInstanceOf(InfluxDBPartialWriteException.class)
+        .hasMessage("HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+          + "\t{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}\n"
+          + "\t{\"error_message\":\"bad line 2\",\"line_number\":\"x\",\"original_line\":\"bad lp 2\"}");
     }
 
     @ParameterizedTest(name = "{0}")
@@ -647,7 +669,8 @@ public class RestClientTest extends AbstractMockServerTest {
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[1,{\"error_message\":"
             + "\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}]}",
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-            + "\tline 2: bad line (bad lp)"
+            + "\t1\n"
+            + "\t{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}"
         ),
         Arguments.of(
           "null error_message skipped",
@@ -671,6 +694,13 @@ public class RestClientTest extends AbstractMockServerTest {
             + "\tsecond issue"
         ),
         Arguments.of(
+          "array of strings fallback",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[\"bad line 1\",\"bad line 2\"]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tbad line 1\n"
+            + "\tbad line 2"
+        ),
+        Arguments.of(
           "textual numeric line_number",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"bad line\",\"line_number\":\"2\",\"original_line\":\"bad lp\"}]}",
@@ -682,7 +712,7 @@ public class RestClientTest extends AbstractMockServerTest {
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"bad line\",\"line_number\":\"x\",\"original_line\":\"bad lp\"}]}",
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-            + "\tline x: bad line (bad lp)"
+            + "\t{\"error_message\":\"bad line\",\"line_number\":\"x\",\"original_line\":\"bad lp\"}"
         ),
         Arguments.of(
           "empty textual line_number with empty original_line",
@@ -695,7 +725,14 @@ public class RestClientTest extends AbstractMockServerTest {
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"bad line\",\"line_number\":true,\"original_line\":\"bad lp\"}]}",
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-            + "\tline true: bad line (bad lp)"
+            + "\t{\"error_message\":\"bad line\",\"line_number\":true,\"original_line\":\"bad lp\"}"
+        ),
+        Arguments.of(
+          "object line_number preserved as text",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"bad line\",\"line_number\":{\"index\":2},\"original_line\":\"bad lp\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\t{\"error_message\":\"bad line\",\"line_number\":{\"index\":2},\"original_line\":\"bad lp\"}"
         )
       );
     }

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -740,12 +740,14 @@ public class RestClientTest extends AbstractMockServerTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("errorFromBodyV3FallbackCases")
     public void errorFromBodyV3FallbackCase(final String testName,
+                                            final String requestPath,
+                                            final String contentType,
                                             final String body,
                                             final Class<? extends InfluxDBApiException> expectedClass,
                                             final String expectedMessage) {
 
       mockServer.enqueue(createResponse(400,
-        "application/json",
+        contentType,
         null,
         body));
 
@@ -753,7 +755,7 @@ public class RestClientTest extends AbstractMockServerTest {
         .host(baseURL)
         .build());
 
-      Throwable thrown = catchThrowable(() -> restClient.request("ping", HttpMethod.GET, null, null, null));
+      Throwable thrown = catchThrowable(() -> restClient.request(requestPath, HttpMethod.GET, null, null, null));
       Assertions.assertThat(thrown)
               .isInstanceOf(expectedClass)
               .hasMessage(expectedMessage);
@@ -763,6 +765,8 @@ public class RestClientTest extends AbstractMockServerTest {
       return Stream.of(
         Arguments.of(
           "missing error with data array falls back to body",
+          "ping",
+          "application/json",
           "{\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}]}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: "
@@ -770,6 +774,8 @@ public class RestClientTest extends AbstractMockServerTest {
         ),
         Arguments.of(
           "empty error with data array falls back to body",
+          "ping",
+          "application/json",
           "{\"error\":\"\",\"data\":[{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":"
             + "\"bad lp\"}]}",
           InfluxDBApiHttpException.class,
@@ -779,39 +785,95 @@ public class RestClientTest extends AbstractMockServerTest {
         ),
         Arguments.of(
           "data object without error_message falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"parsing failed\",\"data\":{}}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data object with empty error_message falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"\"}}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data string falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"parsing failed\",\"data\":\"not-an-object\"}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "data number falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"parsing failed\",\"data\":123}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: parsing failed"
         ),
         Arguments.of(
           "partial-write with invalid data string falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":\"invalid\"}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: partial write of line protocol occurred"
         ),
         Arguments.of(
           "partial-write with empty data object falls back to error",
+          "ping",
+          "application/json",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":{}}",
           InfluxDBApiHttpException.class,
           "HTTP status code: 400; Message: partial write of line protocol occurred"
+        ),
+        Arguments.of(
+          "write endpoint ignores line-error parsing for non-json content type",
+          "api/v3/write_lp",
+          "text/plain",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"bad line\","
+            + "\"line_number\":2,\"original_line\":\"bad lp\"}]}",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: "
+            + "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"bad line\","
+            + "\"line_number\":2,\"original_line\":\"bad lp\"}]}"
+        ),
+        Arguments.of(
+          "write endpoint with non-object root falls back to body",
+          "api/v3/write_lp",
+          "application/json",
+          "[]",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: []"
+        ),
+        Arguments.of(
+          "write endpoint with invalid line-error object type falls back to http exception",
+          "api/v3/write_lp",
+          "application/json",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"bad line\","
+            + "\"line_number\":{\"x\":2},\"original_line\":\"bad lp\"}}",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: bad line"
+        ),
+        Arguments.of(
+          "write endpoint with scalar data falls back to error",
+          "api/v3/write_lp",
+          "application/json",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":123}",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: partial write of line protocol occurred"
+        ),
+        Arguments.of(
+          "write endpoint invalid json body falls back to raw body",
+          "api/v3/write_lp",
+          "application/json",
+          "{\"error\":\"partial write of line protocol occurred\"",
+          InfluxDBApiHttpException.class,
+          "HTTP status code: 400; Message: {\"error\":\"partial write of line protocol occurred\""
         )
       );
     }

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -541,7 +541,7 @@ public class RestClientTest extends AbstractMockServerTest {
       mockServer.enqueue(createResponse(400,
         "application/json",
         null,
-        "{\"error\":\"parsing failed\",\"data\":{\"error_message\":\"invalid field value\"}}"));
+        "{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\"}}"));
 
       restClient = new RestClient(new ClientConfig.Builder()
               .host(baseURL)

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -551,7 +551,8 @@ public class RestClientTest extends AbstractMockServerTest {
       Assertions.assertThat(thrown)
               .isInstanceOf(InfluxDBPartialWriteException.class)
               .isInstanceOf(InfluxDBApiHttpException.class)
-              .hasMessage("HTTP status code: 400; Message: invalid field value");
+              .hasMessage("HTTP status code: 400; Message: parsing failed for write_lp endpoint:\n"
+                      + "\tinvalid field value");
 
       InfluxDBPartialWriteException partialWriteException = (InfluxDBPartialWriteException) thrown;
       Assertions.assertThat(partialWriteException.statusCode()).isEqualTo(400);

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -669,6 +669,33 @@ public class RestClientTest extends AbstractMockServerTest {
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
             + "\tline 2: bad line (bad lp)\n"
             + "\tsecond issue"
+        ),
+        Arguments.of(
+          "textual numeric line_number",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"bad line\",\"line_number\":\"2\",\"original_line\":\"bad lp\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tline 2: bad line (bad lp)"
+        ),
+        Arguments.of(
+          "textual non-numeric line_number",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"bad line\",\"line_number\":\"x\",\"original_line\":\"bad lp\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tline x: bad line (bad lp)"
+        ),
+        Arguments.of(
+          "empty textual line_number with empty original_line",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"only error message\",\"line_number\":\"\",\"original_line\":\"\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n\tonly error message"
+        ),
+        Arguments.of(
+          "non-textual line_number",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"bad line\",\"line_number\":true,\"original_line\":\"bad lp\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tline true: bad line (bad lp)"
         )
       );
     }

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -858,7 +858,7 @@ public class RestClientTest extends AbstractMockServerTest {
           "{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"bad line\","
             + "\"line_number\":{\"x\":2},\"original_line\":\"bad lp\"}}",
           InfluxDBApiHttpException.class,
-          "HTTP status code: 400; Message: bad line"
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n\tbad line"
         ),
         Arguments.of(
           "write endpoint with scalar data falls back to error",

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -71,6 +71,9 @@ class WriteOptionsTest {
         WriteOptions acceptPartialMismatch = new WriteOptions.Builder()
                 .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true)
                 .acceptPartial(false).build();
+        WriteOptions useV2ApiMismatch = new WriteOptions.Builder()
+                .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true)
+                .useV2Api(true).build();
         WriteOptions defaultTagsMismatch = new WriteOptions.Builder()
                 .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true)
                 .defaultTags(Map.of("region", "west")).build();
@@ -84,6 +87,7 @@ class WriteOptionsTest {
         Assertions.assertThat(options).isNotEqualTo(gzipMismatch);
         Assertions.assertThat(options).isNotEqualTo(noSyncMismatch);
         Assertions.assertThat(options).isNotEqualTo(acceptPartialMismatch);
+        Assertions.assertThat(options).isNotEqualTo(useV2ApiMismatch);
         Assertions.assertThat(options).isNotEqualTo(defaultTagsMismatch);
         Assertions.assertThat(options).isNotEqualTo(tagOrderMismatch);
         Assertions.assertThat(options).isNotEqualTo(headersMismatch);
@@ -153,6 +157,7 @@ class WriteOptionsTest {
         Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WriteOptions.DEFAULT_WRITE_PRECISION);
         Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(WriteOptions.DEFAULT_GZIP_THRESHOLD);
         Assertions.assertThat(options.acceptPartialSafe(config)).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
+        Assertions.assertThat(options.useV2ApiSafe(config)).isEqualTo(WriteOptions.DEFAULT_USE_V2_API);
         Assertions.assertThat(options.tagOrderSafe()).isEmpty();
 
         WriteOptions builderOptions = new WriteOptions.Builder().build();
@@ -160,6 +165,7 @@ class WriteOptionsTest {
         Assertions.assertThat(builderOptions.precisionSafe(config)).isEqualTo(WritePrecision.S);
         Assertions.assertThat(builderOptions.gzipThresholdSafe(config)).isEqualTo(512);
         Assertions.assertThat(builderOptions.acceptPartialSafe(config)).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
+        Assertions.assertThat(builderOptions.useV2ApiSafe(config)).isEqualTo(WriteOptions.DEFAULT_USE_V2_API);
     }
 
     @Test
@@ -246,12 +252,39 @@ class WriteOptionsTest {
         ClientConfig config = configBuilder
                 .database("my-database")
                 .organization("my-org")
-                .writeAcceptPartial(true)
+                .writeAcceptPartial(false)
                 .build();
 
-        WriteOptions options = new WriteOptions.Builder().acceptPartial(false).build();
+        WriteOptions options = new WriteOptions.Builder().acceptPartial(true).build();
 
-        Assertions.assertThat(options.acceptPartialSafe(config)).isEqualTo(false);
+        Assertions.assertThat(options.acceptPartialSafe(config)).isEqualTo(true);
+    }
+
+    @Test
+    void optionsOverrideWriteUseV2Api() {
+        ClientConfig config = configBuilder
+                .database("my-database")
+                .organization("my-org")
+                .writeUseV2Api(false)
+                .build();
+
+        WriteOptions options = new WriteOptions.Builder().useV2Api(true).build();
+
+        Assertions.assertThat(options.useV2ApiSafe(config)).isEqualTo(true);
+    }
+
+    @Test
+    void optionsValidateUseV2ApiAndNoSync() {
+        ClientConfig config = configBuilder.build();
+
+        WriteOptions options = new WriteOptions.Builder()
+                .useV2Api(true)
+                .noSync(true)
+                .build();
+
+        Assertions.assertThatThrownBy(() -> options.validate(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid write options: NoSync cannot be used in V2 API");
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -57,9 +57,10 @@ class WriteOptionsTest {
 
     @Test
     void optionsEqualAll() {
-        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512, true);
+        WriteOptions options = new WriteOptions("my-database", WritePrecision.S, 512, true, true, null, null, null);
         WriteOptions optionsViaBuilder = new WriteOptions.Builder()
-                .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true).build();
+                .database("my-database").precision(WritePrecision.S).gzipThreshold(512)
+                .noSync(true).acceptPartial(true).build();
 
         Assertions.assertThat(options).isEqualTo(optionsViaBuilder);
 
@@ -67,6 +68,9 @@ class WriteOptionsTest {
                 .database("my-database").precision(WritePrecision.S).gzipThreshold(1024).noSync(true).build();
         WriteOptions noSyncMismatch = new WriteOptions.Builder()
                 .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(false).build();
+        WriteOptions acceptPartialMismatch = new WriteOptions.Builder()
+                .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true)
+                .acceptPartial(false).build();
         WriteOptions defaultTagsMismatch = new WriteOptions.Builder()
                 .database("my-database").precision(WritePrecision.S).gzipThreshold(512).noSync(true)
                 .defaultTags(Map.of("region", "west")).build();
@@ -79,6 +83,7 @@ class WriteOptionsTest {
 
         Assertions.assertThat(options).isNotEqualTo(gzipMismatch);
         Assertions.assertThat(options).isNotEqualTo(noSyncMismatch);
+        Assertions.assertThat(options).isNotEqualTo(acceptPartialMismatch);
         Assertions.assertThat(options).isNotEqualTo(defaultTagsMismatch);
         Assertions.assertThat(options).isNotEqualTo(tagOrderMismatch);
         Assertions.assertThat(options).isNotEqualTo(headersMismatch);
@@ -147,12 +152,14 @@ class WriteOptionsTest {
         Assertions.assertThat(options.databaseSafe(config)).isEqualTo("my-database");
         Assertions.assertThat(options.precisionSafe(config)).isEqualTo(WriteOptions.DEFAULT_WRITE_PRECISION);
         Assertions.assertThat(options.gzipThresholdSafe(config)).isEqualTo(WriteOptions.DEFAULT_GZIP_THRESHOLD);
+        Assertions.assertThat(options.acceptPartialSafe(config)).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
         Assertions.assertThat(options.tagOrderSafe()).isEmpty();
 
         WriteOptions builderOptions = new WriteOptions.Builder().build();
         Assertions.assertThat(builderOptions.databaseSafe(config)).isEqualTo("my-database");
         Assertions.assertThat(builderOptions.precisionSafe(config)).isEqualTo(WritePrecision.S);
         Assertions.assertThat(builderOptions.gzipThresholdSafe(config)).isEqualTo(512);
+        Assertions.assertThat(builderOptions.acceptPartialSafe(config)).isEqualTo(WriteOptions.DEFAULT_ACCEPT_PARTIAL);
     }
 
     @Test
@@ -235,6 +242,19 @@ class WriteOptionsTest {
     }
 
     @Test
+    void optionsOverrideWriteAcceptPartial() {
+        ClientConfig config = configBuilder
+                .database("my-database")
+                .organization("my-org")
+                .writeAcceptPartial(true)
+                .build();
+
+        WriteOptions options = new WriteOptions.Builder().acceptPartial(false).build();
+
+        Assertions.assertThat(options.acceptPartialSafe(config)).isEqualTo(false);
+    }
+
+    @Test
     void optionsOverridesDefaultTags() {
         Map<String, String> defaultTagsBase = new HashMap<>() {{
             put("model", "train");
@@ -303,6 +323,8 @@ class WriteOptionsTest {
           .isNotEqualTo(builder.database("my-database").build().hashCode());
         Assertions.assertThat(baseOptions.hashCode())
           .isNotEqualTo(builder.defaultTags(defaultTags).build().hashCode());
+        Assertions.assertThat(baseOptions.hashCode())
+          .isNotEqualTo(builder.acceptPartial(true).build().hashCode());
         Assertions.assertThat(baseOptions.hashCode())
           .isNotEqualTo(builder.tagOrder(List.of("region", "host")).build().hashCode());
     }


### PR DESCRIPTION
## Proposed Changes

Adds partial-write support with structured error details in `InfluxDBPartialWriteException`, including per-line `line_number`, `error_message`, and `original_line` so callers can decide whether to drop/retry/fix specific lines in a batch.

This also aligns write routing with the rollout contract:

  - Default write endpoint is now `/api/v3/write_lp`
  - `acceptPartial` defaults to `true` (server default behavior)
  - `accept_partial=false` is sent only when partial writes are explicitly disabled
  - New compatibility option `useV2Api` routes writes to `/api/v2/write` for Clustered/v2-compatible backends

Configuration surfaces now include:

  - Write option: `acceptPartial`, `useV2Api`
  - Client config / connection string keys: `writeAcceptPartial`, `writeUseV2Api`
  - Environment variables: `INFLUX_WRITE_ACCEPT_PARTIAL`, `INFLUX_WRITE_USE_V2_API`

Validation:

  - `useV2Api=true` with `noSync=true` is rejected before request dispatch.

See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) in InfluxDB documentation.

```java
try {
    client.writeRecord(lp);
} catch (InfluxDBPartialWriteException e) {
    for (InfluxDBPartialWriteException.LineError lineErr : e.lineErrors()) {
        System.out.printf(
                "line %s failed: %s (%s)%n",
                lineErr.lineNumber(),
                lineErr.errorMessage(),
                lineErr.originalLine()
        );
    }
} catch (InfluxDBApiHttpException e) {
    System.out.println(e.getMessage());
}
```

Optional v2 compatibility mode:

```java
WriteOptions v2Compat = new WriteOptions.Builder()
        .useV2Api(true)
        .build();

InfluxDBClient client = InfluxDBClient.getInstance(
        ...,
        v2Compat
);

client.writeRecord(lp);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
