### PR TITLE
fix: send correct time unit when writing Points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
    For InfluxDB Clustered version, set `useV2Api=true` for writing.
 
+### Bug Fixes
+
+1. [#384](https://github.com/InfluxCommunity/influxdb3-java/pull/384): Always set `precision` to `nanosecond` when
+   writing Points.
+
 ## 1.9.0 [2026-04-23]
 
 ### Features

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -53,7 +53,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>authScheme</code> - authentication scheme</li>
  *     <li><code>organization</code> - organization to be used for operations</li>
  *     <li><code>database</code> - database to be used for InfluxDB operations</li>
- *     <li><code>writePrecision</code> - precision to use when writing points to InfluxDB.
+ *     <li><code>writePrecision</code> - precision to use when writing to InfluxDB.
  *      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
  *      for those writes, the client always sends {@link WritePrecision#NS}
  *      precision to the server.</li>
@@ -550,7 +550,7 @@ public final class ClientConfig {
          * Sets the default precision to use for the timestamp of points
          * if no precision is specified in the write API call.
          *
-         * @param writePrecision default precision to use for the timestamp of points
+         * @param writePrecision default precision to use for the timestamp
          *                       if no precision is specified in the write API call.
          *                       This setting is ignored when writing {@link com.influxdb.v3.client.Point};
          *                       for those writes, the client always sends {@link WritePrecision#NS}

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -53,7 +53,10 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>authScheme</code> - authentication scheme</li>
  *     <li><code>organization</code> - organization to be used for operations</li>
  *     <li><code>database</code> - database to be used for InfluxDB operations</li>
- *     <li><code>writePrecision</code> - precision to use when writing points to InfluxDB</li>
+ *     <li><code>writePrecision</code> - precision to use when writing points to InfluxDB.
+ *      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+ *      for those writes, the client always sends {@link WritePrecision#NS}
+ *      precision to the server.</li>
  *     <li><code>defaultTags</code> - defaultTags added when writing points to InfluxDB</li>
  *     <li><code>gzipThreshold</code> - threshold when gzip compression is used for writing points to InfluxDB</li>
  *     <li><code>writeNoSync</code> - skip waiting for WAL persistence on write</li>
@@ -548,7 +551,10 @@ public final class ClientConfig {
          * if no precision is specified in the write API call.
          *
          * @param writePrecision default precision to use for the timestamp of points
-         *                       if no precision is specified in the write API call
+         *                       if no precision is specified in the write API call.
+         *                       This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+         *                       for those writes, the client always sends {@link WritePrecision#NS}
+         *                       precision to the server.
          * @return this
          */
         @Nonnull

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -304,7 +304,14 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
                     + "or use default configuration at 'ClientConfig.database'.");
         }
 
-        WritePrecision precision = options.precisionSafe(config);
+        WritePrecision precision;
+
+        if (isWritePoint(data)) {
+            // When writing Point(s), the timestamp is always converted to nanoseconds.
+            precision = WritePrecision.NS;
+        } else {
+            precision = options.precisionSafe(config);
+        }
         options.validate(config);
 
         String path;
@@ -471,5 +478,14 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         gzip.close();
 
         return out.toByteArray();
+    }
+
+    private <T> boolean isWritePoint(@Nonnull final List<T> data) {
+        for (T writeAble : data) {
+            if (writeAble instanceof Point) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -124,7 +124,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -40,7 +40,9 @@ import com.influxdb.v3.client.internal.Arguments;
  * <ul>
  *     <li><code>database</code> - specifies the database to be used for InfluxDB operations</li>
  *     <li><code>organization</code> - specifies the organization to be used for InfluxDB operations</li>
- *     <li><code>precision</code> - specifies the precision to use for the timestamp of points</li>
+ *     <li><code>precision</code> - specifies the precision to use for timestamps in line protocol records.
+ *     This setting is ignored when writing {@link com.influxdb.v3.client.Point}; for those writes, the client
+ *     always sends {@link WritePrecision#NS} precision to the server.</li>
  *     <li><code>defaultTags</code> - specifies tags to be added by default to all write operations using points.</li>
  *     <li><code>tagOrder</code> - specifies preferred tag order for point serialization.</li>
  *     <li><code>noSync</code> - skip waiting for WAL persistence on write</li>
@@ -124,6 +126,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      */
@@ -140,6 +145,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param defaultTags   Default tags to be added when writing points.
@@ -158,6 +166,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param noSync        Skip waiting for WAL persistence on write.
@@ -187,6 +198,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param defaultTags   Default tags to be added when writing points.
@@ -209,6 +223,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param noSync        Skip waiting for WAL persistence on write.
@@ -234,6 +251,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param noSync        Skip waiting for WAL persistence on write.
@@ -265,6 +285,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param noSync        Skip waiting for WAL persistence on write.
@@ -307,6 +330,9 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
      * @param precision     The precision to use for the timestamp of points.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
+     *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
+     *                      for those writes, the client always sends {@link WritePrecision#NS}
+     *                      precision to the server.
      * @param gzipThreshold The threshold for compressing request body.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_GZIP_THRESHOLD}.
      * @param noSync        Skip waiting for WAL persistence on write.

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -143,7 +143,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -164,7 +164,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -196,7 +196,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -221,7 +221,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -249,7 +249,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -283,7 +283,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}
@@ -328,7 +328,7 @@ public final class WriteOptions {
      *
      * @param database      The database to be used for InfluxDB operations.
      *                      If it is not specified then use {@link ClientConfig#getDatabase()}.
-     * @param precision     The precision to use for the timestamp of points.
+     * @param precision     The precision to use for the timestamp.
      *                      If it is not specified then use {@link ClientConfig#getWritePrecision()}.
      *                      This setting is ignored when writing {@link com.influxdb.v3.client.Point};
      *                      for those writes, the client always sends {@link WritePrecision#NS}

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -456,6 +456,43 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         checkWriteCalled("/api/v3/write_lp", "DB", expectedPrecision, true, "true", null, true);
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("pointPrecisionIgnoredCases")
+    void pointWritesIgnoreWriteOptionsPrecision(
+            String name,
+            WritePrecision configuredPrecision,
+            boolean manyPoints) throws Exception {
+        mockServer.enqueue(createResponse(200));
+        ClientConfig cfg = new ClientConfig.Builder()
+                .host(baseURL)
+                .token("TOKEN".toCharArray())
+                .database("DB")
+                .build();
+        try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
+            Point point = new Point("mem");
+            point.setTag("tag", "one");
+            point.setField("value", 1.0);
+            WriteOptions options = new WriteOptions.Builder()
+                    .precision(configuredPrecision)
+                    .build();
+            if (manyPoints) {
+                client.writePoints(List.of(point), options);
+            } else {
+                client.writePoint(point, options);
+            }
+        }
+        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+    }
+
+    private static Stream<Arguments> pointPrecisionIgnoredCases() {
+        return Stream.of(
+                Arguments.of("writePoint precision=S", WritePrecision.S, false),
+                Arguments.of("writePoint precision=MS", WritePrecision.MS, false),
+                Arguments.of("writePoints precision=S", WritePrecision.S, true),
+                Arguments.of("writePoints precision=US", WritePrecision.US, true)
+        );
+    }
+
     private void checkWriteCalled(final String expectedPath, final String expectedDB,
                                   final String expectedPrecision, final boolean expectedV3,
                                   @Nullable final String expectedNoSync,

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -459,9 +459,9 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("pointPrecisionIgnoredCases")
     void pointWritesIgnoreWriteOptionsPrecision(
-            String name,
-            WritePrecision configuredPrecision,
-            boolean manyPoints) throws Exception {
+            @Nonnull final String name,
+            @Nonnull final WritePrecision configuredPrecision,
+            final boolean manyPoints) throws Exception {
         mockServer.enqueue(createResponse(200));
         ClientConfig cfg = new ClientConfig.Builder()
                 .host(baseURL)

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -412,7 +412,10 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
+        // When writing Point, precision sent to the server is always nanosecond
+        var expectedPrecision = "nanosecond";
+
+        checkWriteCalled("/api/v3/write_lp", "DB", expectedPrecision, true, "true", null, true);
     }
 
     @Test
@@ -447,7 +450,10 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "second", true, "true", null, true);
+        // When writing Point, precision sent to the server is always nanosecond
+        var expectedPrecision = "nanosecond";
+
+        checkWriteCalled("/api/v3/write_lp", "DB", expectedPrecision, true, "true", null, true);
     }
 
     private void checkWriteCalled(final String expectedPath, final String expectedDB,

--- a/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
+++ b/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
@@ -595,10 +595,43 @@ public class E2ETest {
                 }
             }
         }
-
-
     }
 
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_URL", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_TOKEN", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "TESTING_INFLUXDB_DATABASE", matches = ".*")
+    @Test
+    public void testWriteWithDifferentTimeUnit() throws Exception {
+        try (InfluxDBClient client = InfluxDBClient.getInstance(
+                System.getenv("TESTING_INFLUXDB_URL"),
+                System.getenv("TESTING_INFLUXDB_TOKEN").toCharArray(),
+                System.getenv("TESTING_INFLUXDB_DATABASE"),
+                null)) {
+            var writeOptions = new WriteOptions.Builder().precision(WritePrecision.MS).build();
+            String measurement = "test_" + UUID.randomUUID();
+            List<Point> points = List.of(
+                Point.measurement(measurement)
+                        .setTag("type", "test")
+                        .setFloatField("rads", 3.14)
+                        .setIntegerField("life", 42)
+                        .setTimestamp(Instant.now().toEpochMilli(), WritePrecision.MS),
+                Point.measurement(measurement)
+                        .setTag("type", "test")
+                        .setFloatField("rads", 3.14)
+                        .setIntegerField("life", 12)
+                        .setTimestamp(Instant.now().plusSeconds(1).getEpochSecond(), WritePrecision.S),
+                Point.measurement(measurement)
+                        .setTag("type", "test")
+                        .setFloatField("rads", 3.14)
+                        .setIntegerField("life", 432)
+                        .setTimestamp(Instant.now().plusSeconds(2).toEpochMilli() * 1000, WritePrecision.US)
+        );
+            client.writePoints(points, writeOptions);
+            var results = client.queryPoints(String.format("select * from \"%s\"", measurement))
+                    .collect(Collectors.toList());
+            Assertions.assertThat(results).hasSize(3);
+        }
+    }
 
     private void assertGetDataSuccess(@Nonnull final InfluxDBClient influxDBClient) {
         influxDBClient.writePoint(


### PR DESCRIPTION
Closes #382 

## Proposed Changes

- When writing Points, `precision` in query parameters always set to `nanosecond` because time in Points always converted into `nanoseconds` by default.
- Update test cases to respect the new changes above.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
