### PR TITLE
fix: partial write support and default write endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 1.10.0 [unreleased]
 
-### Breaking Changes
+### Features
 
-1. [#365](https://github.com/InfluxCommunity/influxdb3-java/pull/365): Adds partial writes support and aligns write routing with v3 defaults.
-   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
-   For InfluxDB Clustered version, set `useV2Api=true` for writing.
+1. [#388](https://github.com/InfluxCommunity/influxdb3-java/pull/388): Adds partial writes support and defaults writes to the V2 API endpoint.
+   - `NoSync` requires `useV2Api=false` and the V3 API endpoint.
+   - `acceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint.
+   - See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 1. [#388](https://github.com/InfluxCommunity/influxdb3-java/pull/388): Adds partial writes support and defaults writes to the V2 API endpoint.
-   - `NoSync` requires `useV2Api=false` and the V3 API endpoint.
+   - `noSync` requires `useV2Api=false` and the V3 API endpoint.
    - `acceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint.
    - See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ try {
 }
 
 //
-// Write via v2 compatibility endpoint (InfluxDB Clustered)
+// Write via V2 API endpoint (InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless)
 //
 WriteOptions useV2 = new WriteOptions.Builder()
         .useV2Api(true)
@@ -150,7 +150,7 @@ client.writeRecord(record);
 
 #### Accept partial writes and inspect failed lines
 
-Partial writes are enabled by default.
+Partial writes are enabled by default when writing through the V3 API endpoint (`useV2Api=false`).
 `acceptPartial` can be configured in three ways: client defaults via `WriteOptions`, connection string / environment variable / system property (`writeAcceptPartial` / `INFLUX_WRITE_ACCEPT_PARTIAL` / `influx.writeAcceptPartial`), or per-write `WriteOptions`.
 
 Set `acceptPartial(false)` to disable partial writes.
@@ -162,13 +162,13 @@ With InfluxDB Core/Enterprise, when a write request fails due to one or more inv
 When partial writes are disabled, any rejected line causes all lines to be rejected.
 InfluxDB Clustered does not return this structured partial-write error format.
 
-#### Compatibility with InfluxDB Clustered
+#### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
 
-For InfluxDB Clustered, enable `useV2Api` for writes.
+Writes use the V2 API endpoint by default.
 Like other write options, this can be configured in client code, connection string / environment variable / system property (`writeUseV2Api` / `INFLUX_WRITE_USE_V2_API` / `influx.writeUseV2Api`), or per-write `WriteOptions`.
 
-If `useV2Api` is set, `acceptPartial` is ignored because this compatibility mode does not support partial-write controls.
-Any rejected line causes all lines to be rejected.
+`NoSync` requires the V3 API endpoint, which is available with InfluxDB 3 Core/Enterprise. `acceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint. To use `NoSync`, set `useV2Api=false`.
+Note: when writes use the V2 API endpoint, `NoSync=true` returns a validation error (`invalid write options: noSync requires useV2Api=false`).
 
 ### Query
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ InfluxDB Clustered does not return this structured partial-write error format.
 Writes use the V2 API endpoint by default.
 Like other write options, this can be configured in client code, connection string / environment variable / system property (`writeUseV2Api` / `INFLUX_WRITE_USE_V2_API` / `influx.writeUseV2Api`), or per-write `WriteOptions`.
 
-`NoSync` requires the V3 API endpoint, which is available with InfluxDB 3 Core/Enterprise. `acceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint. To use `NoSync`, set `useV2Api=false`.
-Note: when writes use the V2 API endpoint, `NoSync=true` returns a validation error (`invalid write options: noSync requires useV2Api=false`).
+`noSync` requires the V3 API endpoint, which is available with InfluxDB 3 Core/Enterprise. `acceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint. To use `noSync`, set `useV2Api=false`.
+Note: when writes use the V2 API endpoint, `noSync=true` returns a validation error (`invalid write options: noSync requires useV2Api=false`).
 
 ### Query
 

--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -558,7 +558,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>gzipThreshold - payload size size for gzipping data</li>
      *   <li>writeNoSync - skip waiting for WAL persistence on write</li>
      *   <li>writeAcceptPartial - accept partial writes</li>
-     *   <li>writeUseV2Api - use v2 compatibility write endpoint</li>
+     *   <li>writeUseV2Api - use V2 API endpoint</li>
      * </ul>
      *
      * @param connectionString connection string
@@ -593,7 +593,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>INFLUX_GZIP_THRESHOLD - payload size size for gzipping data</li>
      *   <li>INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write</li>
      *   <li>INFLUX_WRITE_ACCEPT_PARTIAL - accept partial writes</li>
-     *   <li>INFLUX_WRITE_USE_V2_API - use v2 compatibility write endpoint</li>
+     *   <li>INFLUX_WRITE_USE_V2_API - use V2 API endpoint</li>
      * </ul>
      * Supported system properties:
      * <ul>
@@ -606,7 +606,7 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>influx.gzipThreshold - payload size size for gzipping data</li>
      *   <li>influx.writeNoSync - skip waiting for WAL persistence on write</li>
      *   <li>influx.writeAcceptPartial - accept partial writes</li>
-     *   <li>influx.writeUseV2Api - use v2 compatibility write endpoint</li>
+     *   <li>influx.writeUseV2Api - use V2 API endpoint</li>
      * </ul>
      *
      * @return instance of {@link InfluxDBClient}

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -61,7 +61,7 @@ import com.influxdb.v3.client.write.WritePrecision;
  *     <li><code>gzipThreshold</code> - threshold when gzip compression is used for writing points to InfluxDB</li>
  *     <li><code>writeNoSync</code> - skip waiting for WAL persistence on write</li>
  *     <li><code>writeAcceptPartial</code> - accept partial writes</li>
- *     <li><code>writeUseV2Api</code> - use v2 compatibility write endpoint</li>
+ *     <li><code>writeUseV2Api</code> - use V2 API endpoint</li>
  *     <li><code>timeout</code> - <i>deprecated in 1.4.0</i> timeout when connecting to InfluxDB,
  *     please use more informative properties <code>writeTimeout</code> and <code>queryTimeout</code></li>
  *     <li><code>writeTimeout</code> - timeout when writing data to InfluxDB</li>
@@ -226,9 +226,9 @@ public final class ClientConfig {
     }
 
     /**
-     * Use v2 compatibility write endpoint?
+     * Use V2 API endpoint?
      *
-     * @return use v2 compatibility write endpoint
+     * @return use V2 API endpoint
      */
     @Nonnull
     public Boolean getWriteUseV2Api() {
@@ -604,9 +604,9 @@ public final class ClientConfig {
         }
 
         /**
-         * Sets whether to use v2 compatibility write endpoint.
+         * Sets whether to use V2 API endpoint.
          *
-         * @param writeUseV2Api use v2 compatibility write endpoint
+         * @param writeUseV2Api use V2 API endpoint
          * @return this
          */
         @Nonnull

--- a/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
+++ b/src/main/java/com/influxdb/v3/client/internal/InfluxDBClientImpl.java
@@ -386,11 +386,21 @@ public final class InfluxDBClientImpl implements InfluxDBClient {
         try {
             restClient.request(path, HttpMethod.POST, body, queryParams, headers);
         } catch (InfluxDBApiHttpException e) {
-            if (!useV2Api && e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
-                throw new InfluxDBApiHttpException("Server doesn't support v3 write API. "
-                        + "Use WriteOptions.Builder.useV2Api(true) for v2 compatibility endpoint.",
-                        e.headers(),
-                        e.statusCode());
+            if (e.statusCode() == HttpResponseStatus.METHOD_NOT_ALLOWED.code()) {
+                if (useV2Api && "api/v2/write".equals(path)) {
+                    throw new InfluxDBApiHttpException(
+                            "Server doesn't support the V2 API endpoint (/api/v2/write). "
+                                    + "Set useV2Api=false to use the V3 API endpoint.",
+                            e.headers(),
+                            e.statusCode());
+                }
+                if (!useV2Api && "api/v3/write_lp".equals(path)) {
+                    throw new InfluxDBApiHttpException(
+                            "Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
+                                    + "Set useV2Api=true to use the V2 API endpoint.",
+                            e.headers(),
+                            e.statusCode());
+                }
             }
             throw e;
         }

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -390,7 +390,9 @@ final class RestClient implements AutoCloseable {
         }
 
         final String value;
-        if (node.isNumber() || node.isBoolean()) {
+        if (node.isTextual()) {
+            value = node.asText();
+        } else if (node.isNumber() || node.isBoolean()) {
             value = node.asText();
         } else {
             value = node.toString();
@@ -435,12 +437,27 @@ final class RestClient implements AutoCloseable {
 
         final List<String> details = new ArrayList<>();
         for (JsonNode item : dataNode) {
-            final String raw = errNonEmptyText(item);
+            final String raw = errNonEmptyRawJsonToken(item);
             if (raw != null) {
                 details.add(raw);
             }
         }
         return details;
+    }
+
+    @Nullable
+    private String errNonEmptyRawJsonToken(@Nullable final JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+
+        final String value;
+        if (node.isNumber() || node.isBoolean()) {
+            value = node.asText();
+        } else {
+            value = node.toString();
+        }
+        return value.isEmpty() ? null : value;
     }
 
     @Nullable

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -424,7 +424,7 @@ final class RestClient implements AutoCloseable {
                     final StringBuilder detail = new StringBuilder()
                             .append("line ").append(lineError.lineNumber())
                             .append(": ").append(lineError.errorMessage());
-                    if (lineError.originalLine() != null && !lineError.originalLine().isEmpty()) {
+                    if (lineError.originalLine() != null) {
                         detail.append(" (").append(lineError.originalLine()).append(")");
                     }
                     details.add(detail.toString());
@@ -457,7 +457,7 @@ final class RestClient implements AutoCloseable {
         } else {
             value = node.toString();
         }
-        return value.isEmpty() ? null : value;
+        return value;
     }
 
     @Nullable

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -390,9 +390,7 @@ final class RestClient implements AutoCloseable {
         }
 
         final String value;
-        if (node.isTextual()) {
-            value = node.asText();
-        } else if (node.isNumber() || node.isBoolean()) {
+        if (node.isNumber() || node.isBoolean()) {
             value = node.asText();
         } else {
             value = node.toString();
@@ -420,11 +418,14 @@ final class RestClient implements AutoCloseable {
                     continue;
                 }
 
-                if (lineError.lineNumber() != null
-                        && lineError.originalLine() != null
-                        && !lineError.originalLine().isEmpty()) {
-                    details.add("line " + lineError.lineNumber() + ": "
-                            + lineError.errorMessage() + " (" + lineError.originalLine() + ")");
+                if (lineError.lineNumber() != null) {
+                    final StringBuilder detail = new StringBuilder()
+                            .append("line ").append(lineError.lineNumber())
+                            .append(": ").append(lineError.errorMessage());
+                    if (lineError.originalLine() != null && !lineError.originalLine().isEmpty()) {
+                        detail.append(" (").append(lineError.originalLine()).append(")");
+                    }
+                    details.add(detail.toString());
                 } else {
                     details.add(lineError.errorMessage());
                 }

--- a/src/main/java/com/influxdb/v3/client/internal/RestClient.java
+++ b/src/main/java/com/influxdb/v3/client/internal/RestClient.java
@@ -446,8 +446,8 @@ final class RestClient implements AutoCloseable {
     }
 
     @Nullable
-    private String errNonEmptyRawJsonToken(@Nullable final JsonNode node) {
-        if (node == null || node.isNull()) {
+    private String errNonEmptyRawJsonToken(@Nonnull final JsonNode node) {
+        if (node.isNull()) {
             return null;
         }
 

--- a/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
+++ b/src/main/java/com/influxdb/v3/client/write/WriteOptions.java
@@ -46,8 +46,8 @@ import com.influxdb.v3.client.internal.Arguments;
  *     <li><code>defaultTags</code> - specifies tags to be added by default to all write operations using points.</li>
  *     <li><code>tagOrder</code> - specifies preferred tag order for point serialization.</li>
  *     <li><code>noSync</code> - skip waiting for WAL persistence on write</li>
- *     <li><code>acceptPartial</code> - accept partial writes</li>
- *     <li><code>useV2Api</code> - use v2 compatibility write endpoint</li>
+ *     <li><code>acceptPartial</code> - accept partial writes on the V3 API endpoint</li>
+ *     <li><code>useV2Api</code> - route writes to the V2 API endpoint</li>
  *     <li><code>headers</code> - specifies the headers to be added to write request</li>
  * </ul>
  * <p>
@@ -80,7 +80,7 @@ public final class WriteOptions {
     /**
      * Default UseV2Api.
      */
-    public static final boolean DEFAULT_USE_V2_API = false;
+    public static final boolean DEFAULT_USE_V2_API = true;
 
   /**
    * Default timeout for writes in seconds. Set to {@value}
@@ -294,7 +294,7 @@ public final class WriteOptions {
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_NO_SYNC}.
      * @param acceptPartial Request partial write acceptance.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_ACCEPT_PARTIAL}.
-     * @param useV2Api      Use v2 compatibility write endpoint.
+     * @param useV2Api      Use V2 API endpoint.
      *                      If it is not specified then use {@link WriteOptions#DEFAULT_USE_V2_API}.
      * @param defaultTags   Default tags to be added when writing points.
      * @param headers       The headers to be added to write request.
@@ -421,7 +421,7 @@ public final class WriteOptions {
 
     /**
      * @param config with default value
-     * @return Use v2 compatibility write endpoint.
+     * @return Route writes to the V2 API endpoint.
      */
     public boolean useV2ApiSafe(@Nonnull final ClientConfig config) {
         Arguments.checkNotNull(config, "config");
@@ -436,7 +436,7 @@ public final class WriteOptions {
     public void validate(@Nonnull final ClientConfig config) {
         Arguments.checkNotNull(config, "config");
         if (useV2ApiSafe(config) && noSyncSafe(config)) {
-            throw new IllegalArgumentException("invalid write options: NoSync cannot be used in V2 API");
+            throw new IllegalArgumentException("invalid write options: noSync requires useV2Api=false");
         }
     }
 
@@ -580,9 +580,9 @@ public final class WriteOptions {
         }
 
         /**
-         * Sets whether to use v2 compatibility write endpoint.
+         * Sets whether to use V2 API endpoint.
          *
-         * @param useV2Api use v2 compatibility write endpoint
+         * @param useV2Api use V2 API endpoint
          * @return this
          */
         @Nonnull

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientWriteTest.java
@@ -112,7 +112,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("db")).isEqualTo("my-database");
+        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("my-database");
     }
 
     @Test
@@ -125,7 +125,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("db")).isEqualTo("my-database-2");
+        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("my-database-2");
     }
 
     @Test
@@ -153,7 +153,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("nanosecond");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("ns");
     }
 
     @Test
@@ -166,7 +166,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("second");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("s");
     }
 
     @Test
@@ -226,13 +226,14 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
 
     private static Stream<Arguments> writeRoutingCases() {
         return Stream.of(
-                Arguments.of("v3 noSync=false", (Consumer<WriteOptions.Builder>) b -> b.noSync(false),
+                Arguments.of("v2 default", (Consumer<WriteOptions.Builder>) b -> {
+                }, "/api/v2/write", "bucket", "ns", null, null),
+                Arguments.of("v3 useV2Api=false", (Consumer<WriteOptions.Builder>) b -> b.useV2Api(false),
                         "/api/v3/write_lp", "db", "nanosecond", null, null),
-                Arguments.of("v3 noSync=true", (Consumer<WriteOptions.Builder>) b -> b.noSync(true),
+                Arguments.of("v3 noSync=true", (Consumer<WriteOptions.Builder>) b -> b.useV2Api(false).noSync(true),
                         "/api/v3/write_lp", "db", "nanosecond", "true", null),
-                Arguments.of("v3 acceptPartial=true", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true),
-                        "/api/v3/write_lp", "db", "nanosecond", null, null),
-                Arguments.of("v3 acceptPartial=false", (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(false),
+                Arguments.of("v3 acceptPartial=false",
+                        (Consumer<WriteOptions.Builder>) b -> b.useV2Api(false).acceptPartial(false),
                         "/api/v3/write_lp", "db", "nanosecond", null, "false"),
                 Arguments.of("v2 useV2Api=true", (Consumer<WriteOptions.Builder>) b -> b.useV2Api(true),
                         "/api/v2/write", "bucket", "ns", null, null),
@@ -243,11 +244,14 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("writeV3MethodNotAllowedCases")
-    void writeV3MethodNotAllowedMappedError(final String name,
+    @MethodSource("writeMethodNotAllowedCases")
+    void writeMethodNotAllowedMappedError(final String name,
                                             final Consumer<WriteOptions.Builder> configure,
+                                            final String expectedPath,
+                                            final String expectedPrecision,
                                             @Nullable final String expectedNoSync,
-                                            @Nullable final String expectedAcceptPartial) throws InterruptedException {
+                                            @Nullable final String expectedAcceptPartial,
+                                            final String expectedMessage) throws InterruptedException {
         mockServer.enqueue(createEmptyResponse(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
 
         WriteOptions.Builder optionsBuilder = new WriteOptions.Builder().precision(WritePrecision.MS);
@@ -261,24 +265,44 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         RecordedRequest request = mockServer.takeRequest();
         assertThat(request).isNotNull();
         assertThat(request.getUrl()).isNotNull();
-        assertThat(request.getUrl().encodedPath()).isEqualTo("/api/v3/write_lp");
+        assertThat(request.getUrl().encodedPath()).isEqualTo(expectedPath);
         assertThat(request.getUrl().queryParameter("no_sync")).isEqualTo(expectedNoSync);
         assertThat(request.getUrl().queryParameter("accept_partial")).isEqualTo(expectedAcceptPartial);
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("millisecond");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo(expectedPrecision);
 
         assertThat(ae.statusCode()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED.code());
-        assertThat(ae.getMessage()).contains("Server doesn't support v3 write API. "
-                + "Use WriteOptions.Builder.useV2Api(true) for v2 compatibility endpoint.");
+        assertThat(ae.getMessage()).isEqualTo(expectedMessage);
     }
 
-    private static Stream<Arguments> writeV3MethodNotAllowedCases() {
+    private static Stream<Arguments> writeMethodNotAllowedCases() {
         return Stream.of(
-                Arguments.of("noSync=true", (Consumer<WriteOptions.Builder>) b -> b.noSync(true), "true", null),
-                Arguments.of(
-                        "acceptPartial=true",
-                        (Consumer<WriteOptions.Builder>) b -> b.acceptPartial(true),
+                Arguments.of("v3 noSync=true",
+                        (Consumer<WriteOptions.Builder>) b -> b.useV2Api(false).noSync(true),
+                        "/api/v3/write_lp",
+                        "millisecond",
+                        "true",
                         null,
-                        null
+                        "Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
+                                + "Set useV2Api=true to use the V2 API endpoint."),
+                Arguments.of(
+                        "v3 acceptPartial=true",
+                        (Consumer<WriteOptions.Builder>) b -> b.useV2Api(false).acceptPartial(true),
+                        "/api/v3/write_lp",
+                        "millisecond",
+                        null,
+                        null,
+                        "Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
+                                + "Set useV2Api=true to use the V2 API endpoint."
+                ),
+                Arguments.of(
+                        "v2 useV2Api=true",
+                        (Consumer<WriteOptions.Builder>) b -> b.useV2Api(true),
+                        "/api/v2/write",
+                        "ms",
+                        null,
+                        null,
+                        "Server doesn't support the V2 API endpoint (/api/v2/write). "
+                                + "Set useV2Api=false to use the V3 API endpoint."
                 )
         );
     }
@@ -290,7 +314,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
 
         Assertions.assertThat(thrown)
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("invalid write options: NoSync cannot be used in V2 API");
+                .hasMessage("invalid write options: noSync requires useV2Api=false");
         assertThat(mockServer.getRequestCount()).isEqualTo(0);
     }
 
@@ -304,7 +328,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -314,6 +338,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
                 .writePrecision(WritePrecision.S)
                 .writeNoSync(true)
+                .writeUseV2Api(false)
                 .gzipThreshold(1)
                 .build();
         try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
@@ -334,7 +359,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecord("mem,tag=one value=1.0");
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -361,7 +386,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writeRecords(List.of("mem,tag=one value=1.0"));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -371,6 +396,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
                 .writePrecision(WritePrecision.S)
                 .writeNoSync(true)
+                .writeUseV2Api(false)
                 .gzipThreshold(1)
                 .build();
         try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
@@ -393,7 +419,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoint(point);
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -403,6 +429,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
                 .writePrecision(WritePrecision.S)
                 .writeNoSync(true)
+                .writeUseV2Api(false)
                 .gzipThreshold(1)
                 .build();
         try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
@@ -431,7 +458,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
             client.writePoints(List.of(point));
         }
 
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     @Test
@@ -441,6 +468,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         ClientConfig cfg = new ClientConfig.Builder().host(baseURL).token("TOKEN".toCharArray()).database("DB")
                 .writePrecision(WritePrecision.S)
                 .writeNoSync(true)
+                .writeUseV2Api(false)
                 .gzipThreshold(1)
                 .build();
         try (InfluxDBClient client = InfluxDBClient.getInstance(cfg)) {
@@ -481,7 +509,7 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
                 client.writePoint(point, options);
             }
         }
-        checkWriteCalled("/api/v3/write_lp", "DB", "nanosecond", true, null, null, false);
+        checkWriteCalled("/api/v2/write", "DB", "ns", false, null, null, false);
     }
 
     private static Stream<Arguments> pointPrecisionIgnoredCases() {
@@ -538,8 +566,8 @@ class InfluxDBClientWriteTest extends AbstractMockServerTest {
         assertThat(request.getUrl()).isNotNull();
         assertThat(request.getHeaders().get("Content-Type")).isEqualTo("text/plain; charset=utf-8");
         assertThat(request.getHeaders().get("Content-Encoding")).isEqualTo("gzip");
-        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("second");
-        assertThat(request.getUrl().queryParameter("db")).isEqualTo("your-database");
+        assertThat(request.getUrl().queryParameter("precision")).isEqualTo("s");
+        assertThat(request.getUrl().queryParameter("bucket")).isEqualTo("your-database");
     }
 
     @Test

--- a/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
+++ b/src/test/java/com/influxdb/v3/client/config/ClientConfigTest.java
@@ -95,7 +95,7 @@ class ClientConfigTest {
         Assertions.assertThat(configString.contains("gzipThreshold=1000")).isEqualTo(true);
         Assertions.assertThat(configString).contains("writeNoSync=false");
         Assertions.assertThat(configString).contains("writeAcceptPartial=true");
-        Assertions.assertThat(configString).contains("writeUseV2Api=false");
+        Assertions.assertThat(configString).contains("writeUseV2Api=true");
         Assertions.assertThat(configString).contains("timeout=PT30S");
         Assertions.assertThat(configString).contains("writeTimeout=PT35S");
         Assertions.assertThat(configString).contains("queryTimeout=PT2M");

--- a/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
+++ b/src/test/java/com/influxdb/v3/client/integration/E2ETest.java
@@ -204,6 +204,7 @@ public class E2ETest {
                     + "home,room=Sunroom temp=88i 1735545620";
 
             WriteOptions options = new WriteOptions.Builder()
+                    .useV2Api(false)
                     .acceptPartial(true)
                     .build();
 
@@ -254,6 +255,7 @@ public class E2ETest {
                     + "home,room=Sunroom temp=88i 1735545620";
 
             WriteOptions options = new WriteOptions.Builder()
+                    .useV2Api(false)
                     .acceptPartial(false)
                     .build();
             Throwable thrown = Assertions.catchThrowable(() -> client.writeRecord(points, options));

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -407,6 +407,41 @@ public class RestClientTest extends AbstractMockServerTest {
               .hasMessage("HTTP status code: 401; Message: token does not have sufficient permissions");
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("errorFromBodyScalarMessageCases")
+    public void errorFromBodyScalarMessage(final String testName,
+                                           final String responseBody,
+                                           final String expectedMessage) {
+
+      mockServer.enqueue(createResponse(401,
+        "application/json",
+        null,
+        responseBody));
+
+      restClient = new RestClient(new ClientConfig.Builder()
+              .host(baseURL)
+              .build());
+
+      Assertions.assertThatThrownBy(
+         () -> restClient.request("ping", HttpMethod.GET, null, null, null)
+      )
+        .isInstanceOf(InfluxDBApiException.class)
+        .hasMessage(expectedMessage);
+    }
+
+    private static Stream<Arguments> errorFromBodyScalarMessageCases() {
+      return Stream.of(
+        Arguments.of(
+          "numeric message",
+          "{\"message\":123}",
+          "HTTP status code: 401; Message: 123"),
+        Arguments.of(
+          "boolean message",
+          "{\"message\":true}",
+          "HTTP status code: 401; Message: true")
+      );
+    }
+
     @Test
     public void errorFromBodyIgnoredForNonJsonContentType() {
       mockServer.enqueue(createResponse(400,

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -688,6 +688,13 @@ public class RestClientTest extends AbstractMockServerTest {
             + "\tline 2: only error message"
         ),
         Arguments.of(
+          "missing original_line uses line-prefixed detail",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"only error message\",\"line_number\":2}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tline 2: only error message"
+        ),
+        Arguments.of(
           "multiple valid details append without extra colon",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"},{\"error_message\":\"second issue\"}]}",
@@ -703,11 +710,25 @@ public class RestClientTest extends AbstractMockServerTest {
             + "\t\"bad line 2\""
         ),
         Arguments.of(
+          "array fallback skips null and renders boolean",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[null,true,\"bad line\"]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\ttrue\n"
+            + "\t\"bad line\""
+        ),
+        Arguments.of(
           "textual numeric line_number",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"bad line\",\"line_number\":\"2\",\"original_line\":\"bad lp\"}]}",
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
             + "\tline 2: bad line (bad lp)"
+        ),
+        Arguments.of(
+          "line_number integer overflow falls back to raw token details",
+          "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
+            + "\"bad line\",\"line_number\":2147483648,\"original_line\":\"bad lp\"}]}",
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\t{\"error_message\":\"bad line\",\"line_number\":2147483648,\"original_line\":\"bad lp\"}"
         ),
         Arguments.of(
           "textual non-numeric line_number",

--- a/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/internal/RestClientTest.java
@@ -684,7 +684,8 @@ public class RestClientTest extends AbstractMockServerTest {
           "empty original_line uses message-only detail",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":"
             + "\"only error message\",\"line_number\":2,\"original_line\":\"\"}]}",
-          "HTTP status code: 400; Message: partial write of line protocol occurred:\n\tonly error message"
+          "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
+            + "\tline 2: only error message"
         ),
         Arguments.of(
           "multiple valid details append without extra colon",
@@ -698,8 +699,8 @@ public class RestClientTest extends AbstractMockServerTest {
           "array of strings fallback",
           "{\"error\":\"partial write of line protocol occurred\",\"data\":[\"bad line 1\",\"bad line 2\"]}",
           "HTTP status code: 400; Message: partial write of line protocol occurred:\n"
-            + "\tbad line 1\n"
-            + "\tbad line 2"
+            + "\t\"bad line 1\"\n"
+            + "\t\"bad line 2\""
         ),
         Arguments.of(
           "textual numeric line_number",

--- a/src/test/java/com/influxdb/v3/client/issues/MemoryLeakIssueTest.java
+++ b/src/test/java/com/influxdb/v3/client/issues/MemoryLeakIssueTest.java
@@ -64,6 +64,7 @@ public class MemoryLeakIssueTest {
                 .token(token.toCharArray())
                 .database(database)
                 .writeNoSync(true)
+                .writeUseV2Api(false)
                 .build();
 
         try (InfluxDBClient client = InfluxDBClient.getInstance(config)) {

--- a/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
+++ b/src/test/java/com/influxdb/v3/client/write/WriteOptionsTest.java
@@ -284,7 +284,7 @@ class WriteOptionsTest {
 
         Assertions.assertThatThrownBy(() -> options.validate(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("invalid write options: NoSync cannot be used in V2 API");
+                .hasMessage("invalid write options: noSync requires useV2Api=false");
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

This PR finalizes partial-write support and fixes regression issue with the default API endpoint behavior introduced in PR #365.

- The client defaults to the V2 API endpoint for writes for broad product compatibility. Since the Java client has not been released yet with the PR #365 behavior, this change is **not breaking**.
- V3 API-only options:
  - `noSync`
  - `acceptPartial`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)