### PR TITLE
docs: document executable JAR service descriptor merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ dependencies {
 }
 ```
 
+### Packaging executable JARs
+
+The query API uses gRPC and Apache Arrow Flight. If you package your application
+as a single executable JAR, make sure `META-INF/services` files from dependencies
+are merged instead of overwritten.
+
+Without this, the application can work from an IDE or Maven classpath but fail
+when started with `java -jar` with an error like:
+
+```text
+java.lang.IllegalArgumentException: Address types of NameResolver 'unix' ... not supported by transport
+```
+
+For the Maven Shade Plugin, add `ServicesResourceTransformer`:
+
+```xml
+<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+```
+
 ## Usage
 
 ### Create client


### PR DESCRIPTION
## Summary

- Document that executable JAR packaging must merge `META-INF/services` files for the query API.
- Add the common `NameResolver 'unix'` error users may see when service descriptors are overwritten.
- Show the Maven Shade `ServicesResourceTransformer` fix.

## Validation

- `mvn -q -DskipTests package`
- `git diff --check`

Related to #404.
