### PR TITLE
chore: upgrade minium Java version to 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default-maven-image:
     type: string
-    default: "cimg/openjdk:11.0"
+    default: "cimg/openjdk:17.0"
 
 executors:
   docker-amd64-image:
@@ -225,7 +225,7 @@ workflows:
             alias: tests-java-jdk-old
             parameters:
               exe: [ docker-amd64-image, docker-arm64-image ]
-              maven-image: [ << pipeline.parameters.default-maven-image >>, "cimg/openjdk:17.0", "cimg/openjdk:21.0" ]
+              maven-image: [ << pipeline.parameters.default-maven-image >>, "cimg/openjdk:21.0" ]
       # Java test matrix for JDK 25+
       - tests-java:
           matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.11.0 [unreleased]
 
+### Breaking Changes
+
+1. [#407](https://github.com/InfluxCommunity/influxdb3-java/pull/407): Upgrade minium jdk requirement to version 17.
+
 ## 1.10.0 [2026-06-11]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-1. [#407](https://github.com/InfluxCommunity/influxdb3-java/pull/407): Upgrade minium jdk requirement to version 17.
+1. [#407](https://github.com/InfluxCommunity/influxdb3-java/pull/407): Upgrade minimum JDK requirement to version 17.
 
 ## 1.10.0 [2026-06-11]
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ which allows you to execute SQL queries against InfluxDB IOx.
 
 We offer this [Getting Started: InfluxDB 3.0 Java Client Library](https://www.youtube.com/watch?v=EFnG7rUDvR4) video for learning more about the library.
 
-> :warning: This client requires Java 11 and is compatible up to and including Java 25.
+> :warning: This client requires Java 17 and is compatible up to and including Java 25.
 
 ## Installation
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -65,7 +65,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -383,9 +383,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>11</source>
-                    <release>11</release>
-                    <target>11</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Closes #

## Proposed Changes

- Upgrade minimum jdk requirement to version 17.
- Motivation for this upgrade is #405 . Junit 6 only working with jdk >= 17. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
