### PR TITLE
test: add test parse ipv6

### DIFF
--- a/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
+++ b/src/main/java/com/influxdb/v3/client/InfluxDBClient.java
@@ -483,7 +483,8 @@ public interface InfluxDBClient extends AutoCloseable {
      * Creates a new instance of the {@link InfluxDBClient} for interacting with an InfluxDB server, simplifying
      * common operations such as writing, querying.
      *
-     * @param host     the URL of the InfluxDB server
+     * @param host     the URL of the InfluxDB server.<br>
+     *                 NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
      * @param token    the authentication token for accessing the InfluxDB server, can be null
      * @param database the database to be used for InfluxDB operations, can be null
      * @return new instance of the {@link InfluxDBClient}
@@ -505,7 +506,8 @@ public interface InfluxDBClient extends AutoCloseable {
      * Creates a new instance of the {@link InfluxDBClient} for interacting with an InfluxDB server, simplifying
      * common operations such as writing, querying.
      *
-     * @param host        the URL of the InfluxDB server
+     * @param host        the URL of the InfluxDB server.<br>
+     *                    NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
      * @param token       the authentication token for accessing the InfluxDB server, can be null
      * @param database    the database to be used for InfluxDB operations, can be null
      * @param defaultTags tags to be added by default to writes of points
@@ -561,7 +563,8 @@ public interface InfluxDBClient extends AutoCloseable {
      *   <li>writeUseV2Api - use V2 API endpoint</li>
      * </ul>
      *
-     * @param connectionString connection string
+     * @param connectionString connection string.<br>
+     *                         NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
      * @return instance of {@link InfluxDBClient}
      */
     @Nonnull
@@ -584,7 +587,10 @@ public interface InfluxDBClient extends AutoCloseable {
      * <p>
      * Supported environment variables:
      * <ul>
-     *   <li>INFLUX_HOST - cloud/server URL <i>required</i></li>
+     *   <li>INFLUX_HOST - cloud/server URL.<br>
+     *   NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
+     *   <i>required</i>
+     *   </li>
      *   <li>INFLUX_TOKEN - authentication token <i>required</i></li>
      *   <li>INFLUX_AUTH_SCHEME - authentication scheme</li>
      *   <li>INFLUX_ORG - organization name</li>
@@ -597,7 +603,8 @@ public interface InfluxDBClient extends AutoCloseable {
      * </ul>
      * Supported system properties:
      * <ul>
-     *   <li>influx.host - cloud/server URL <i>required</i></li>
+     *   <li>influx.host - cloud/server URL.<br>
+     *   NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1]. <i>required</i></li>
      *   <li>influx.token - authentication token <i>required</i></li>
      *   <li>influx.authScheme - authentication scheme</li>
      *   <li>influx.org - organization name</li>

--- a/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
+++ b/src/main/java/com/influxdb/v3/client/config/ClientConfig.java
@@ -24,6 +24,8 @@ package com.influxdb.v3.client.config;
 import java.net.Authenticator;
 import java.net.MalformedURLException;
 import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Arrays;
@@ -48,7 +50,10 @@ import com.influxdb.v3.client.write.WritePrecision;
  * <p>
  * You can configure following properties:
  * <ul>
- *     <li><code>host</code> - hostname or IP address of the InfluxDB server</li>
+ *     <li>
+ *         <code>host</code> - hostname or IP address of the InfluxDB server.<br>
+ *         NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
+ *     </li>
  *     <li><code>token</code> - authentication token for accessing the InfluxDB server</li>
  *     <li><code>authScheme</code> - authentication scheme</li>
  *     <li><code>organization</code> - organization to be used for operations</li>
@@ -375,8 +380,17 @@ public final class ClientConfig {
      * Validates the configuration properties.
      */
     public void validate() {
-        if (host == null || host.isBlank()) {
-            throw new IllegalArgumentException("The URL of the InfluxDB server has to be defined.");
+        try {
+            if (host == null || host.isBlank()) {
+                throw new IllegalArgumentException("Invalid URL.");
+            }
+
+            URI uri = new URI(host);
+            if (uri.getHost() == null) {
+                throw new URISyntaxException(host, "Invalid URL.");
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid URL.");
         }
     }
 
@@ -481,7 +495,8 @@ public final class ClientConfig {
         private List<ClientInterceptor> interceptors;
 
         /**
-         * Sets the URL of the InfluxDB server.
+         * Sets the URL of the InfluxDB server.<br>
+         * NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
          *
          * @param host URL of the InfluxDB server
          * @return this
@@ -827,7 +842,8 @@ public final class ClientConfig {
         /**
          * Build an instance of {@code ClientConfig} from connection string.
          *
-         * @param connectionString connection string in URL format
+         * @param connectionString connection string in URL format.<br>
+         *                         NOTE: IPv6 must be wrapped inside square brackets .e.g: http://[2001:db8::1].
          * @return the configuration for an {@code InfluxDBClient}
          * @throws MalformedURLException when argument is not valid URL
          */

--- a/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
+++ b/src/test/java/com/influxdb/v3/client/InfluxDBClientTest.java
@@ -21,6 +21,9 @@
  */
 package com.influxdb.v3.client;
 
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -41,6 +44,38 @@ public class InfluxDBClientTest {
     }
 
     @Test
+    void parseIpv6() throws UnknownHostException, URISyntaxException {
+        record Test(String url, boolean isCorrect) {
+        }
+        var tests = List.of(
+                new Test("http://[2001:db8::1]/", true),
+                new Test("http://[2001:db8:a0b:12f0::1]/index.html", true),
+                new Test("http://[2001:db8:a0b:12f0::1]:80/index.html", true),
+                new Test("https://[2001:db8:a0b:12f0::1%25eth0]:15000/", true),
+                new Test("http://[2607:f8b0:4005:802::1007]/", true),
+                new Test("http://2001:db8::1/", false),
+                new Test("http://2001:db8::1:8080/", false)
+        );
+        for (Test test : tests) {
+            if (!test.isCorrect()) {
+                Assertions.assertThatThrownBy(() -> {
+                    try (var client = InfluxDBClient.getInstance(test.url(), "my-token".toCharArray(), "bucket0")) {
+                        client.getServerVersion();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }).hasMessageContaining("Invalid URL.");
+            } else {
+                Assertions.assertThatNoException().isThrownBy(() -> {
+                    try (var ignored = InfluxDBClient.getInstance(test.url(), "my-token".toCharArray(), "bucket0")) {
+                        Assertions.assertThat(true);
+                    }
+                });
+            }
+        }
+    }
+
+    @Test
     void withSslRootsFilePath() {
         String path = "/path/to/cert";
         ClientConfig.Builder builder = new ClientConfig.Builder();
@@ -51,10 +86,13 @@ public class InfluxDBClientTest {
 
     @Test
     void requiredHost() {
-
         Assertions.assertThatThrownBy(() -> InfluxDBClient.getInstance(null, "my-token".toCharArray(), "my-database"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("The URL of the InfluxDB server has to be defined.");
+                .hasMessage("Invalid URL.");
+
+        Assertions.assertThatThrownBy(() -> InfluxDBClient.getInstance(" ", "my-token".toCharArray(), "my-database"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid URL.");
     }
 
     @Test


### PR DESCRIPTION
Closes #

## Proposed Changes

- Add tests for ipv6, I only check if our clients can parse the addresses correctly. Real communication tests need to be created inside a machine executor in CircleCI, and It is not worth the efforts, already talked with Jakub about this. 
- Add comments to let users know that ipv6 must be used with square brackets. This is because we are using `java.net.URI` package.

I don't think these changes need to be in CHANGELOG.md

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
